### PR TITLE
fix(settings): support partial saves and safe prompt migrations

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -1667,6 +1667,9 @@
   "OPTIONS_STATUS_SAVED_SUCCESS": {
     "message": "Saved successfully :)"
   },
+  "OPTIONS_STATUS_SAVED_WITH_PROMPT_ERRORS": {
+    "message": "Settings saved, but invalid prompt templates were not saved."
+  },
   "OPTIONS_STATUS_SAVED_FAILED": {
     "message": "Save failed :("
   },

--- a/src/_locales/fa/messages.json
+++ b/src/_locales/fa/messages.json
@@ -1667,6 +1667,9 @@
   "OPTIONS_STATUS_SAVED_SUCCESS": {
     "message": "با موفقیت ذخیره شد :)"
   },
+  "OPTIONS_STATUS_SAVED_WITH_PROMPT_ERRORS": {
+    "message": "تنظیمات ذخیره شد، اما الگوهای نامعتبر پرامپت ذخیره نشدند."
+  },
   "OPTIONS_STATUS_SAVED_FAILED": {
     "message": "ذخیره نشد :("
   },

--- a/src/_locales/ja/messages.json
+++ b/src/_locales/ja/messages.json
@@ -1667,6 +1667,9 @@
   "OPTIONS_STATUS_SAVED_SUCCESS": {
     "message": "保存しました :)"
   },
+  "OPTIONS_STATUS_SAVED_WITH_PROMPT_ERRORS": {
+    "message": "設定は保存されましたが、無効なプロンプトテンプレートは保存されませんでした。"
+  },
   "OPTIONS_STATUS_SAVED_FAILED": {
     "message": "保存に失敗しました :("
   },

--- a/src/components/layout/OptionsNavigation.test.js
+++ b/src/components/layout/OptionsNavigation.test.js
@@ -1,0 +1,134 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { mount, flushPromises } from '@vue/test-utils';
+import { ref, reactive, computed } from 'vue';
+import OptionsNavigation from './OptionsNavigation.vue';
+
+// Mock vue-router
+const pushMock = vi.fn();
+const currentRouteName = ref('languages');
+vi.mock('vue-router', () => ({
+  useRouter: () => ({
+    push: pushMock,
+    currentRoute: computed(() => ({ name: currentRouteName.value }))
+  })
+}));
+
+// Mock useUnifiedI18n composable
+vi.mock('@/composables/shared/useUnifiedI18n.js', () => ({
+  useUnifiedI18n: () => ({
+    t: (key) => key,
+    locale: ref('en')
+  })
+}));
+
+// Mock settings store
+const mockValidateSettings = vi.fn();
+const mockSaveSettings = vi.fn();
+const mockSettingsStore = reactive({
+  settings: {
+    TRANSLATION_API: 'google',
+    MODE_PROVIDERS: {}
+  },
+  validateSettings: mockValidateSettings,
+  saveAllSettings: mockSaveSettings
+});
+
+vi.mock('@/features/settings/stores/settings.js', () => ({
+  useSettingsStore: () => mockSettingsStore
+}));
+
+// Mock safeSendMessage & settingsManager
+vi.mock('@/shared/messaging/core/UnifiedMessaging.js', () => ({
+  safeSendMessage: vi.fn()
+}));
+vi.mock('@/shared/managers/SettingsManager.js', () => ({
+  settingsManager: {
+    get: vi.fn(),
+    set: vi.fn(),
+    refreshSettings: vi.fn()
+  }
+}));
+
+describe('OptionsNavigation.vue - Save Validation UX', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    currentRouteName.value = 'languages';
+    mockSettingsStore.settings = {
+      TRANSLATION_API: 'google',
+      MODE_PROVIDERS: {}
+    };
+  });
+
+  it('valid settings allows save successfully', async () => {
+    mockValidateSettings.mockReturnValue({ isValid: true, errors: [] });
+    
+    const wrapper = mount(OptionsNavigation, {
+      global: {
+        stubs: {
+          RouterLink: true
+        },
+        mocks: {
+          $route: {
+            name: 'languages'
+          }
+        }
+      }
+    });
+
+    const saveButton = wrapper.find('#saveSettings');
+    expect(saveButton.exists()).toBe(true);
+    
+    await saveButton.trigger('click');
+    await flushPromises();
+    
+    expect(mockValidateSettings).toHaveBeenCalled();
+    expect(mockSaveSettings).toHaveBeenCalled();
+    expect(wrapper.find('#status').text()).toBe('OPTIONS_STATUS_SAVED_SUCCESS');
+  });
+
+  it('invalid prompt template blocks save, sets error status, and triggers redirect', async () => {
+    // Return prompt validation error
+    mockValidateSettings.mockReturnValue({ 
+      isValid: false, 
+      errors: ['prompt:PROMPT_TEMPLATE:validation_prompt_template_empty'] 
+    });
+    
+    const wrapper = mount(OptionsNavigation, {
+      global: {
+        stubs: {
+          RouterLink: true
+        },
+        mocks: {
+          $route: {
+            name: 'languages'
+          }
+        }
+      }
+    });
+
+    // Setup custom event listener to verify options-trigger-validation-feedback event is fired
+    const customEventListener = vi.fn();
+    window.addEventListener('options-trigger-validation-feedback', customEventListener);
+
+    const saveButton = wrapper.find('#saveSettings');
+    await saveButton.trigger('click');
+    await flushPromises();
+    
+    // Save should NOT be called
+    expect(mockValidateSettings).toHaveBeenCalled();
+    expect(mockSaveSettings).not.toHaveBeenCalled();
+    
+    // Status should be set to validation_prompt_template_empty error
+    expect(wrapper.find('#status').text()).toBe('validation_prompt_template_empty');
+    expect(wrapper.find('#status').classes()).toContain('status-error');
+
+    // Route should change to prompt tab
+    expect(pushMock).toHaveBeenCalledWith({ name: 'prompt' });
+    
+    // Window validation feedback event should be dispatched
+    expect(customEventListener).toHaveBeenCalled();
+    
+    // Clean up event listener
+    window.removeEventListener('options-trigger-validation-feedback', customEventListener);
+  });
+});

--- a/src/components/layout/OptionsNavigation.test.js
+++ b/src/components/layout/OptionsNavigation.test.js
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { mount, flushPromises } from '@vue/test-utils';
 import { ref, reactive, computed } from 'vue';
 import OptionsNavigation from './OptionsNavigation.vue';
+import { storageManager } from '@/shared/storage/core/StorageCore.js';
 
 // Mock vue-router
 const pushMock = vi.fn();
@@ -27,7 +28,8 @@ const mockSaveSettings = vi.fn();
 const mockSettingsStore = reactive({
   settings: {
     TRANSLATION_API: 'google',
-    MODE_PROVIDERS: {}
+    MODE_PROVIDERS: {},
+    PROMPT_TEMPLATE: 'valid template $_{SOURCE} $_{TARGET} $_{TEXT}'
   },
   validateSettings: mockValidateSettings,
   saveAllSettings: mockSaveSettings
@@ -49,14 +51,29 @@ vi.mock('@/shared/managers/SettingsManager.js', () => ({
   }
 }));
 
-describe('OptionsNavigation.vue - Save Validation UX', () => {
+// Mock storageManager safely
+vi.mock('@/shared/storage/core/StorageCore.js', () => ({
+  storageManager: {
+    get: vi.fn(),
+    set: vi.fn()
+  }
+}));
+
+describe('OptionsNavigation.vue - Save Validation UX & Partial Save', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     currentRouteName.value = 'languages';
     mockSettingsStore.settings = {
       TRANSLATION_API: 'google',
-      MODE_PROVIDERS: {}
+      MODE_PROVIDERS: {},
+      PROMPT_TEMPLATE: 'original valid template $_{SOURCE} $_{TARGET} $_{TEXT}'
     };
+    
+    vi.mocked(storageManager.get).mockResolvedValue({
+      PROMPT_TEMPLATE: 'last persisted template $_{SOURCE} $_{TARGET} $_{TEXT}'
+    });
+    vi.mocked(storageManager.set).mockResolvedValue(true);
+    mockSaveSettings.mockResolvedValue(true);
   });
 
   it('valid settings allows save successfully', async () => {
@@ -86,13 +103,16 @@ describe('OptionsNavigation.vue - Save Validation UX', () => {
     expect(wrapper.find('#status').text()).toBe('OPTIONS_STATUS_SAVED_SUCCESS');
   });
 
-  it('invalid prompt template blocks save, sets error status, and triggers redirect', async () => {
-    // Return prompt validation error
+  it('prompt-only validation error triggers partial save and restores draft', async () => {
+    // 1. Setup mock validation failure for prompts only
     mockValidateSettings.mockReturnValue({ 
       isValid: false, 
       errors: ['prompt:PROMPT_TEMPLATE:validation_prompt_template_empty'] 
     });
-    
+
+    // Set draft invalid value in local store state
+    mockSettingsStore.settings.PROMPT_TEMPLATE = 'invalid draft template';
+
     const wrapper = mount(OptionsNavigation, {
       global: {
         stubs: {
@@ -106,29 +126,122 @@ describe('OptionsNavigation.vue - Save Validation UX', () => {
       }
     });
 
-    // Setup custom event listener to verify options-trigger-validation-feedback event is fired
+    // Monitor the value of the settings during the actual save call
+    let valueDuringSave = null;
+    mockSaveSettings.mockImplementation(() => {
+      valueDuringSave = mockSettingsStore.settings.PROMPT_TEMPLATE;
+      return Promise.resolve(true);
+    });
+
+    // Setup custom event listener for redirect / validation feedback
     const customEventListener = vi.fn();
     window.addEventListener('options-trigger-validation-feedback', customEventListener);
 
     const saveButton = wrapper.find('#saveSettings');
     await saveButton.trigger('click');
     await flushPromises();
+
+    // Save should run!
+    expect(mockSaveSettings).toHaveBeenCalled();
+
+    // Persisted payload during the save should have reverted to last persisted value
+    expect(valueDuringSave).toBe('last persisted template $_{SOURCE} $_{TARGET} $_{TEXT}');
+
+    // UI/Store state should be restored to the user's invalid draft
+    expect(mockSettingsStore.settings.PROMPT_TEMPLATE).toBe('invalid draft template');
+
+    // Warning status should be shown
+    expect(wrapper.find('#status').text()).toBe('OPTIONS_STATUS_SAVED_WITH_PROMPT_ERRORS');
+    expect(wrapper.find('#status').classes()).toContain('status-warning');
+
+    // Redirect to prompt tab and focus should still happen
+    expect(pushMock).toHaveBeenCalledWith({ name: 'prompt' });
+    expect(customEventListener).toHaveBeenCalledWith(
+      expect.objectContaining({
+        detail: { field: 'prompt', promptKey: 'PROMPT_TEMPLATE' }
+      })
+    );
+
+    window.removeEventListener('options-trigger-validation-feedback', customEventListener);
+  });
+
+  it('mixed validation errors (prompt + non-prompt) completely blocks save', async () => {
+    // Set current route name to prompt, so redirect to languages is forced to trigger
+    currentRouteName.value = 'prompt';
+
+    // Return both prompt error and language error
+    mockValidateSettings.mockReturnValue({ 
+      isValid: false, 
+      errors: [
+        'validation_source_language_empty',
+        'prompt:PROMPT_TEMPLATE:validation_prompt_template_empty'
+      ] 
+    });
     
-    // Save should NOT be called
-    expect(mockValidateSettings).toHaveBeenCalled();
+    const wrapper = mount(OptionsNavigation, {
+      global: {
+        stubs: {
+          RouterLink: true
+        },
+        mocks: {
+          $route: {
+            name: 'prompt'
+          }
+        }
+      }
+    });
+
+    const saveButton = wrapper.find('#saveSettings');
+    await saveButton.trigger('click');
+    await flushPromises();
+    
+    // Save should NOT run
     expect(mockSaveSettings).not.toHaveBeenCalled();
     
-    // Status should be set to validation_prompt_template_empty error
-    expect(wrapper.find('#status').text()).toBe('validation_prompt_template_empty');
+    // Status should be set to validation_source_language_empty error (non-prompt error)
+    expect(wrapper.find('#status').text()).toBe('validation_source_language_empty');
     expect(wrapper.find('#status').classes()).toContain('status-error');
 
-    // Route should change to prompt tab
-    expect(pushMock).toHaveBeenCalledWith({ name: 'prompt' });
+    // Redirect should go to languages tab
+    expect(pushMock).toHaveBeenCalledWith({ name: 'languages' });
+  });
+
+  it('save failure during temporary swap restores invalid draft values', async () => {
+    mockValidateSettings.mockReturnValue({ 
+      isValid: false, 
+      errors: ['prompt:PROMPT_TEMPLATE:validation_prompt_template_empty'] 
+    });
+
+    mockSettingsStore.settings.PROMPT_TEMPLATE = 'invalid draft template';
     
-    // Window validation feedback event should be dispatched
-    expect(customEventListener).toHaveBeenCalled();
+    // Save operation throws an error
+    mockSaveSettings.mockRejectedValue(new Error('Save failed'));
+
+    const wrapper = mount(OptionsNavigation, {
+      global: {
+        stubs: {
+          RouterLink: true
+        },
+        mocks: {
+          $route: {
+            name: 'languages'
+          }
+        }
+      }
+    });
+
+    const saveButton = wrapper.find('#saveSettings');
+    await saveButton.trigger('click');
+    await flushPromises();
+
+    // Save was attempted
+    expect(mockSaveSettings).toHaveBeenCalled();
+
+    // Draft is restored even after save failure
+    expect(mockSettingsStore.settings.PROMPT_TEMPLATE).toBe('invalid draft template');
     
-    // Clean up event listener
-    window.removeEventListener('options-trigger-validation-feedback', customEventListener);
+    // Status is set to failure
+    expect(wrapper.find('#status').text()).toBe('OPTIONS_STATUS_SAVED_FAILED');
+    expect(wrapper.find('#status').classes()).toContain('status-error');
   });
 });

--- a/src/components/layout/OptionsNavigation.vue
+++ b/src/components/layout/OptionsNavigation.vue
@@ -82,6 +82,24 @@ const saveAllSettings = async () => {
   if (!validation.isValid) {
     logger.debug('Cannot save settings: Validation failed', validation.errors)
     
+    // Set user-visible error feedback globally for all validation failures
+    statusType.value = 'error'
+    const firstError = validation.errors[0]
+    
+    // Specific translation logic for prompt-based validation keys
+    if (firstError && firstError.startsWith('prompt:')) {
+      const parts = firstError.split(':')
+      const subError = parts.length >= 3 ? parts[2] : 'validation_prompt_template_empty'
+      statusMessage.value = t(subError) || t('OPTIONS_STATUS_VALIDATION_FAILED') || 'Please fix errors before saving'
+    } else {
+      statusMessage.value = t(firstError) || t('OPTIONS_STATUS_VALIDATION_FAILED') || 'Please fix errors before saving'
+    }
+    
+    setTimeout(() => {
+      statusMessage.value = ''
+      statusType.value = ''
+    }, 5000)
+
     // Check if it's a provider configuration error
     const globalProvider = settingsStore.settings.TRANSLATION_API;
     const missingKey = getFirstMissingSetting(globalProvider, settingsStore.settings);
@@ -183,14 +201,6 @@ const saveAllSettings = async () => {
       return
     }
 
-    // For other errors, show the specific error message to help debugging
-    statusType.value = 'error'
-    const firstError = validation.errors[0]
-    
-    // Try to translate the error key, or use a default if it fails
-    statusMessage.value = t(firstError) || t('OPTIONS_STATUS_VALIDATION_FAILED') || 'Please fix errors before saving'
-    
-    setTimeout(() => { statusMessage.value = ''; statusType.value = ''; }, 5000)
     return
   }
 

--- a/src/components/layout/OptionsNavigation.vue
+++ b/src/components/layout/OptionsNavigation.vue
@@ -40,6 +40,8 @@ import { safeSendMessage } from '@/shared/messaging/core/UnifiedMessaging.js'
 import { MessageActions } from '@/shared/messaging/core/MessageActions.js'
 import { getFirstMissingSetting } from '@/features/translation/utils/providerValidator.js'
 import { PROMPT_REGISTRY } from '@/shared/config/PromptRegistry.js'
+import { storageManager } from '@/shared/storage/core/StorageCore.js'
+import { CONFIG } from '@/shared/config/config.js'
 
 const logger = getScopedLogger(LOG_COMPONENTS.UI, 'OptionsNavigation')
 
@@ -74,6 +76,103 @@ const statusType = ref('')
 const isSaving = ref(false)
 
 // Save all settings
+// Shared post-save notification/refresh helper
+const postSaveNotify = async () => {
+  // Refresh settings in all content scripts
+  await settingsManager.refreshSettings()
+
+  // Notify all tabs about settings change using cross-browser compatible approach
+  await safeSendMessage({
+    action: MessageActions.SETTINGS_UPDATED,
+    timestamp: Date.now()
+  }, 'settings-notification')
+  logger.debug('All settings update notification sent to all tabs')
+}
+
+// Partial save helper for prompt-only validation errors
+const performPartialSave = async (errors) => {
+  const invalidPromptKeys = errors.map(e => {
+    const parts = e.split(':')
+    return parts.length >= 2 ? parts[1] : null
+  }).filter(Boolean)
+
+  isSaving.value = true
+  statusType.value = ''
+  statusMessage.value = ''
+
+  const drafts = {}
+
+  try {
+    // 1. Get the last persisted settings from storage
+    const lastSavedSettings = (await storageManager.get(null)) || {}
+
+    // 2. Temporarily swap invalid prompt keys to last persisted or default value
+    for (const key of invalidPromptKeys) {
+      drafts[key] = settingsStore.settings[key]
+      
+      const fallbackValue = lastSavedSettings[key] !== undefined
+        ? lastSavedSettings[key]
+        : (CONFIG[key] !== undefined ? CONFIG[key] : '')
+        
+      settingsStore.settings[key] = fallbackValue
+    }
+
+    // 3. Save the rest of settings (which are valid)
+    await settingsStore.saveAllSettings(true)
+    logger.debug('Valid settings saved successfully; invalid prompts were ignored.')
+
+    // 4. Trigger cross-context updates
+    await postSaveNotify()
+
+    // 5. Set warning status
+    statusType.value = 'warning'
+    statusMessage.value = t('OPTIONS_STATUS_SAVED_WITH_PROMPT_ERRORS') || 'Settings saved, but invalid prompt templates were not saved.'
+
+    setTimeout(() => {
+      if (statusType.value === 'warning') {
+        statusMessage.value = ''
+        statusType.value = ''
+      }
+    }, 3000)
+  } catch (error) {
+    logger.error('Failed to save settings partially:', error)
+    statusType.value = 'error'
+    statusMessage.value = t('OPTIONS_STATUS_SAVED_FAILED') || 'Failed to save settings!'
+
+    setTimeout(() => {
+      if (statusType.value === 'error') {
+        statusMessage.value = ''
+        statusType.value = ''
+      }
+    }, 3000)
+  } finally {
+    // 6. Restore drafts in UI settingsStore
+    for (const key of invalidPromptKeys) {
+      if (drafts[key] !== undefined) {
+        settingsStore.settings[key] = drafts[key]
+      }
+    }
+    isSaving.value = false
+  }
+
+  // 7. Keep redirect/highlight behavior
+  const firstError = errors.find(e => e.startsWith('prompt:'))
+  if (firstError) {
+    const parts = firstError.split(':')
+    const promptKey = parts.length >= 2 ? parts[1] : null
+    
+    if (promptKey && PROMPT_REGISTRY[promptKey]) {
+      if (router.currentRoute.value.name !== 'prompt') {
+        await router.push({ name: 'prompt' })
+      }
+      window.dispatchEvent(new CustomEvent('options-trigger-validation-feedback', { 
+        detail: { field: 'prompt', promptKey } 
+      }))
+    }
+  }
+}
+
+// Save all settings
 const saveAllSettings = async () => {
   logger.debug('Save All Settings clicked!')
   
@@ -82,125 +181,134 @@ const saveAllSettings = async () => {
   if (!validation.isValid) {
     logger.debug('Cannot save settings: Validation failed', validation.errors)
     
-    // Set user-visible error feedback globally for all validation failures
-    statusType.value = 'error'
-    const firstError = validation.errors[0]
+    // Check if every validation error is a prompt error
+    const promptOnlyErrors = validation.errors.every(e => e.startsWith('prompt:'))
     
-    // Specific translation logic for prompt-based validation keys
-    if (firstError && firstError.startsWith('prompt:')) {
-      const parts = firstError.split(':')
-      const subError = parts.length >= 3 ? parts[2] : 'validation_prompt_template_empty'
-      statusMessage.value = t(subError) || t('OPTIONS_STATUS_VALIDATION_FAILED') || 'Please fix errors before saving'
-    } else {
-      statusMessage.value = t(firstError) || t('OPTIONS_STATUS_VALIDATION_FAILED') || 'Please fix errors before saving'
-    }
-    
-    setTimeout(() => {
-      statusMessage.value = ''
-      statusType.value = ''
-    }, 5000)
-
-    // Check if it's a provider configuration error
-    const globalProvider = settingsStore.settings.TRANSLATION_API;
-    const missingKey = getFirstMissingSetting(globalProvider, settingsStore.settings);
-    
-    if (missingKey) {
-      // Redirect to providers tab with highlight parameter if not already there
-      const currentRoute = router.currentRoute.value.name
-      if (currentRoute !== 'providers') {
-        await router.push({ name: 'providers', query: { highlight: missingKey } })
+    if (!promptOnlyErrors) {
+      // Keep current full-block behavior
+      statusType.value = 'error'
+      const firstError = validation.errors.find(e => !e.startsWith('prompt:')) || validation.errors[0]
+      
+      // Specific translation logic for prompt-based validation keys
+      if (firstError && firstError.startsWith('prompt:')) {
+        const parts = firstError.split(':')
+        const subError = parts.length >= 3 ? parts[2] : 'validation_prompt_template_empty'
+        statusMessage.value = t(subError) || t('OPTIONS_STATUS_VALIDATION_FAILED') || 'Please fix errors before saving'
       } else {
-        // Already on providers tab, just dispatch the event
-        window.dispatchEvent(new CustomEvent('options-trigger-validation-feedback', { 
-          detail: { field: missingKey } 
-        }))
+        statusMessage.value = t(firstError) || t('OPTIONS_STATUS_VALIDATION_FAILED') || 'Please fix errors before saving'
       }
-      return
-    }
+      
+      setTimeout(() => {
+        statusMessage.value = ''
+        statusType.value = ''
+      }, 5000)
 
-    // Check mode-specific providers for Activation tab
-    if (settingsStore.settings.MODE_PROVIDERS) {
-      for (const [mode, providerId] of Object.entries(settingsStore.settings.MODE_PROVIDERS)) {
-        if (providerId && providerId !== 'default') {
-          const modeMissingKey = getFirstMissingSetting(providerId, settingsStore.settings);
-          if (modeMissingKey) {
-            // Redirect to activation tab if it's a mode managed there
-            const currentRoute = router.currentRoute.value.name
-            if (currentRoute !== 'activation') {
-              await router.push({ name: 'activation' })
+      // Check if it's a provider configuration error
+      const globalProvider = settingsStore.settings.TRANSLATION_API;
+      const missingKey = getFirstMissingSetting(globalProvider, settingsStore.settings);
+      
+      if (missingKey) {
+        // Redirect to providers tab with highlight parameter if not already there
+        const currentRoute = router.currentRoute.value.name
+        if (currentRoute !== 'providers') {
+          await router.push({ name: 'providers', query: { highlight: missingKey } })
+        } else {
+          // Already on providers tab, just dispatch the event
+          window.dispatchEvent(new CustomEvent('options-trigger-validation-feedback', { 
+            detail: { field: missingKey } 
+          }))
+        }
+        return
+      }
+
+      // Check mode-specific providers for Activation tab
+      if (settingsStore.settings.MODE_PROVIDERS) {
+        for (const [mode, providerId] of Object.entries(settingsStore.settings.MODE_PROVIDERS)) {
+          if (providerId && providerId !== 'default') {
+            const modeMissingKey = getFirstMissingSetting(providerId, settingsStore.settings);
+            if (modeMissingKey) {
+              // Redirect to activation tab if it's a mode managed there
+              const currentRoute = router.currentRoute.value.name
+              if (currentRoute !== 'activation') {
+                await router.push({ name: 'activation' })
+              }
+              window.dispatchEvent(new CustomEvent('options-trigger-validation-feedback', { 
+                detail: { field: 'provider', mode } 
+              }))
+              return
             }
-            window.dispatchEvent(new CustomEvent('options-trigger-validation-feedback', { 
-              detail: { field: 'provider', mode } 
-            }))
-            return
           }
         }
       }
-    }
 
-    // Handle language validation errors
-    if (validation.errors.some(e => e.includes('language'))) {
-      if (router.currentRoute.value.name !== 'languages') {
-        await router.push({ name: 'languages' })
-      }
-      window.dispatchEvent(new CustomEvent('options-trigger-validation-feedback', { 
-        detail: { field: 'languages' } 
-      }))
-      return
-    }
-
-    // Handle prompt validation errors
-    const promptError = validation.errors.find(e => e.startsWith('prompt:'))
-    if (promptError) {
-      const parts = promptError.split(':')
-      const promptKey = parts.length >= 2 ? parts[1] : null
-      
-      if (promptKey && PROMPT_REGISTRY[promptKey]) {
-        if (router.currentRoute.value.name !== 'prompt') {
-          await router.push({ name: 'prompt' })
+      // Handle language validation errors
+      if (validation.errors.some(e => e.includes('language'))) {
+        if (router.currentRoute.value.name !== 'languages') {
+          await router.push({ name: 'languages' })
         }
         window.dispatchEvent(new CustomEvent('options-trigger-validation-feedback', { 
-          detail: { field: 'prompt', promptKey } 
+          detail: { field: 'languages' } 
         }))
         return
-      } else {
-        logger.warn('Received malformed or unknown prompt validation error:', promptError)
       }
-    }
 
-    // Handle activation tab validation errors (scroll delay)
-    if (validation.errors.includes('validation_scroll_delay_invalid')) {
-      if (router.currentRoute.value.name !== 'activation') {
-        await router.push({ name: 'activation' })
+      // Handle prompt validation errors
+      const promptError = validation.errors.find(e => e.startsWith('prompt:'))
+      if (promptError) {
+        const parts = promptError.split(':')
+        const promptKey = parts.length >= 2 ? parts[1] : null
+        
+        if (promptKey && PROMPT_REGISTRY[promptKey]) {
+          if (router.currentRoute.value.name !== 'prompt') {
+            await router.push({ name: 'prompt' })
+          }
+          window.dispatchEvent(new CustomEvent('options-trigger-validation-feedback', { 
+            detail: { field: 'prompt', promptKey } 
+          }))
+          return
+        } else {
+          logger.warn('Received malformed or unknown prompt validation error:', promptError)
+        }
       }
-      window.dispatchEvent(new CustomEvent('options-trigger-validation-feedback', { 
-        detail: { field: 'WHOLE_PAGE_SCROLL_STOP_DELAY' } 
-      }))
+
+      // Handle activation tab validation errors (scroll delay)
+      if (validation.errors.includes('validation_scroll_delay_invalid')) {
+        if (router.currentRoute.value.name !== 'activation') {
+          await router.push({ name: 'activation' })
+        }
+        window.dispatchEvent(new CustomEvent('options-trigger-validation-feedback', { 
+          detail: { field: 'WHOLE_PAGE_SCROLL_STOP_DELAY' } 
+        }))
+        return
+      }
+
+      // Handle font validation errors
+      if (validation.errors.includes('font_size_range_error') || validation.errors.includes('font_family_required')) {
+        if (router.currentRoute.value.name !== 'appearance') {
+          await router.push({ name: 'appearance' })
+        }
+        window.dispatchEvent(new CustomEvent('options-trigger-validation-feedback', { 
+          detail: { field: 'font_settings' } 
+        }))
+        return
+      }
+
+      // Handle proxy validation errors
+      if (validation.errors.some(e => e.includes('proxy'))) {
+        if (router.currentRoute.value.name !== 'advance') {
+          await router.push({ name: 'advance' })
+        }
+        window.dispatchEvent(new CustomEvent('options-trigger-validation-feedback', { 
+          detail: { field: 'proxy' } 
+        }))
+        return
+      }
+
       return
     }
 
-    // Handle font validation errors
-    if (validation.errors.includes('font_size_range_error') || validation.errors.includes('font_family_required')) {
-      if (router.currentRoute.value.name !== 'appearance') {
-        await router.push({ name: 'appearance' })
-      }
-      window.dispatchEvent(new CustomEvent('options-trigger-validation-feedback', { 
-        detail: { field: 'font_settings' } 
-      }))
-      return
-    }
-
-    // Handle proxy validation errors
-    if (validation.errors.some(e => e.includes('proxy'))) {
-      if (router.currentRoute.value.name !== 'advance') {
-        await router.push({ name: 'advance' })
-      }
-      window.dispatchEvent(new CustomEvent('options-trigger-validation-feedback', { 
-        detail: { field: 'proxy' } 
-      }))
-      return
-    }
-
+    // Call partial save if errors are exclusively prompt template errors
+    await performPartialSave(validation.errors)
     return
   }
 
@@ -212,17 +320,11 @@ const saveAllSettings = async () => {
     await settingsStore.saveAllSettings()
     logger.debug('All settings saved successfully')
 
-    // Refresh settings in all content scripts
-    await settingsManager.refreshSettings()
+    // Trigger post-save notifications
+    await postSaveNotify()
 
-    // Notify all tabs about settings change using cross-browser compatible approach
-    await safeSendMessage({
-      action: MessageActions.SETTINGS_UPDATED,
-      timestamp: Date.now()
-    }, 'settings-notification')
-    logger.debug('All settings update notification sent to all tabs')
     statusType.value = 'success'
-  statusMessage.value = t('OPTIONS_STATUS_SAVED_SUCCESS') || 'Settings saved successfully!'
+    statusMessage.value = t('OPTIONS_STATUS_SAVED_SUCCESS') || 'Settings saved successfully!'
     
     // Clear status after 2 seconds
     setTimeout(() => {
@@ -232,7 +334,7 @@ const saveAllSettings = async () => {
   } catch (error) {
     logger.error('Failed to save settings:', error)
     statusType.value = 'error'
-  statusMessage.value = t('OPTIONS_STATUS_SAVED_FAILED') || 'Failed to save settings!'
+    statusMessage.value = t('OPTIONS_STATUS_SAVED_FAILED') || 'Failed to save settings!'
     
     // Clear status after 3 seconds
     setTimeout(() => {

--- a/src/shared/config/config.js
+++ b/src/shared/config/config.js
@@ -284,9 +284,6 @@ export const CONFIG = {
   DICTIONARY_SHOW_DEFINITIONS: false,
   DICTIONARY_SHOW_EXAMPLES: false,
 
-  // --- Versioning ---
-  PROMPTS_VERSION: 6, // Version of the prompt templates (localized labels for dictionary)
-
   // --- AI Optimization Settings ---
   OPTIMIZATION_LEVEL: 3, // Default global optimization level (1-5: Cost vs Speed)
   PROVIDER_OPTIMIZATION_LEVELS: {}, // Per-provider level overrides { Gemini: 5, OpenAI: 2 }

--- a/src/shared/config/promptHistoricalDefaults.js
+++ b/src/shared/config/promptHistoricalDefaults.js
@@ -1,0 +1,48 @@
+/**
+ * Historical Prompt Defaults Registry
+ * 
+ * ============================================================================
+ * WHY HISTORICAL DEFAULTS EXIST:
+ * When editable prompt templates are updated in Translate-It, we need a way
+ * to upgrade users who are using the default templates to the latest version,
+ * while strictly preserving user-customized prompts.
+ * 
+ * HOW SAFE PROMPT MIGRATION WORKS:
+ * 1. Missing Prompt: If a prompt key is missing in user settings, we add the current CONFIG default.
+ * 2. Empty Prompt: If a prompt is empty or blank, we restore the current CONFIG default.
+ * 3. Exact Current Default Match: If the stored prompt exactly matches the current CONFIG default,
+ *    we leave it unchanged.
+ * 4. Historical Default Match: If the stored prompt matches any of the legacy defaults registered
+ *    in this file, it means the user never customized it. We safely upgrade it to the latest CONFIG default.
+ * 5. Customized Prompt: If it does not match current or legacy defaults, we preserve the user's edits.
+ * 
+ * WHEN DEVELOPERS MUST ADD ENTRIES:
+ * Whenever you modify a default prompt in `src/shared/config/config.js` (e.g., changing CONFIG.PROMPT_TEMPLATE):
+ * 1. Copy the EXACT previous multi-line default string.
+ * 2. Add it to this registry under the corresponding prompt key as a new object:
+ *    {
+ *      version: 'vX.Y.Z',      // The version range in which this default was active
+ *      reason: 'Description',  // Why the default was changed (e.g. 'Added formatting support')
+ *      value: `...`            // The exact legacy default template string
+ *    }
+ * 3. Users may upgrade across multiple versions. Keep old legacy defaults in this file
+ *    indefinitely to ensure all updating users can be safely migrated.
+ * ============================================================================
+ */
+
+export const HISTORICAL_PROMPT_DEFAULTS = {
+  PROMPT_TEMPLATE: [
+    // Example:
+    // {
+    //   version: 'v1.17.0',
+    //   reason: 'Initial general prompt template',
+    //   value: '...'
+    // }
+  ],
+  PROMPT_TEMPLATE_AUTO: [],
+  PROMPT_BASE_FIELD: [],
+  PROMPT_BASE_FIELD_AUTO: [],
+  PROMPT_BASE_POPUP_TRANSLATE: [],
+  PROMPT_BASE_DICTIONARY: [],
+  PROMPT_SUBTITLE_USER: []
+};

--- a/src/shared/config/settingsMigrations.js
+++ b/src/shared/config/settingsMigrations.js
@@ -1,21 +1,91 @@
 /**
  * Settings Migration System
- * Handles automatic migrations for user settings when extension is updated
+ * 
+ * Registry of historical default prompt templates used for safe prompt migrations.
  *
- * This system automatically:
- * 1. Adds any missing settings from CONFIG to user settings
- * 2. Updates model lists while preserving user selections
- * 3. Updates prompt templates only if user hasn't customized them
- * 4. Preserves user data, API keys, and customizations
+ * If a user's prompt matches one of these historical defaults, it is assumed
+ * that the prompt was never customized and can be safely upgraded to the
+ * latest CONFIG default.
  *
- * Migration is triggered only on extension update via InstallHandler
+ * Migration rules:
+ * - Missing prompt -> replaced with current CONFIG default.
+ * - Empty prompt -> replaced with current CONFIG default.
+ * - Historical default -> upgraded to current CONFIG default.
+ * - Any other value -> treated as a user customization and preserved.
+ *
+ * IMPORTANT:
+ * Whenever a default prompt template is changed in CONFIG, the previous
+ * default value MUST be added to the corresponding array below.
+ *
+ * Example:
+ *
+ * Before:
+ * CONFIG.PROMPT_TEMPLATE = "Prompt A"
+ *
+ * After:
+ * CONFIG.PROMPT_TEMPLATE = "Prompt B"
+ *
+ * Add:
+ * HISTORICAL_PROMPT_DEFAULTS.PROMPT_TEMPLATE.push("Prompt A")
+ *
+ * This allows users who still have the old unmodified default to receive
+ * the new version automatically, while preserving customized prompts.
+ *
+ * Versioning Notes:
+ * - Keep historical defaults grouped by release/version when possible.
+ * - Do not remove old entries unless you are certain no supported upgrade
+ *   path can reference them anymore.
+ * - Users may upgrade across multiple versions, so migrations must support
+ *   direct upgrades from older releases.
+ *
+ * Example:
+ *
+ * PROMPT_TEMPLATE: [
+ *   // v1.17.0 default
+ *   "Prompt A",
+ *
+ *   // v1.18.0 default
+ *   "Prompt B"
+ * ]
+ *
+ * NOTE:
+ * PROMPTS_VERSION must not be used to force-overwrite prompt templates.
+ * User customizations must always be preserved.
  */
 
 import { CONFIG, TranslationMode } from './config.js';
+import { PROMPT_REGISTRY } from './PromptRegistry.js';
 import { getScopedLogger } from '@/shared/logging/logger.js';
 import { LOG_COMPONENTS } from '@/shared/logging/logConstants.js';
 
 const logger = getScopedLogger(LOG_COMPONENTS.CONFIG, 'SettingsMigrations');
+
+/**
+ * Registry of historical default prompt templates to identify unmodified user prompts.
+ * If a user's prompt matches one of these, it means they never customized it, 
+ * so it is safe to auto-upgrade to the latest default template.
+ */
+export const HISTORICAL_PROMPT_DEFAULTS = {
+  // Example:
+  // PROMPT_TEMPLATE: [
+  // v1.17.0 default
+  //   `Old prompt...`,
+  //
+  // v1.18.0 default
+  //   `Previous prompt...`
+  // ],
+  //
+  // When changing a default prompt in CONFIG, add the previous
+  // default value here before replacing it.
+
+  PROMPT_TEMPLATE: [],
+  PROMPT_TEMPLATE_AUTO: [],
+  PROMPT_BASE_FIELD: [],
+  PROMPT_BASE_FIELD_AUTO: [],
+  PROMPT_BASE_POPUP_TRANSLATE: [],
+  PROMPT_BASE_DICTIONARY: [],
+  PROMPT_SUBTITLE_USER: []
+};
 
 /**
  * Migrate MODE_PROVIDERS keys from old format (underscore) to new format (hyphenated/MessageContexts)
@@ -144,10 +214,10 @@ function runMainMigration(currentSettings) {
   });
 
   // 3. Dynamic Prompt Detection
-  // Automatically identifies all prompt templates to ensure they stay updated
-  const PROMPT_TEMPLATES = Object.keys(CONFIG).filter(key => 
-    key.startsWith('PROMPT_BASE_') || key === 'PROMPT_TEMPLATE'
-  );
+  // Automatically identifies all editable prompt templates from the registry
+  const PROMPT_TEMPLATES = Object.values(PROMPT_REGISTRY)
+    .filter(p => p.editable)
+    .map(p => p.key);
 
   // 4. Synchronized Option Lists (UI Options that should always match CONFIG)
   const OPTION_LISTS = [
@@ -187,33 +257,56 @@ function runMainMigration(currentSettings) {
     }
   });
 
-  // C. Handle prompt templates - update to latest version
-  // We only force update if the PROMPTS_VERSION has increased.
-  // This allows us to push critical prompt updates (like logical batching) 
-  // while preserving user customizations during minor version updates.
+  // C. Handle prompt templates - safe update using historical defaults
   const currentPromptsVersion = currentSettings.PROMPTS_VERSION || 1;
   const targetPromptsVersion = CONFIG.PROMPTS_VERSION || 1;
-  const forceUpdatePrompts = targetPromptsVersion > currentPromptsVersion;
 
   PROMPT_TEMPLATES.forEach(key => {
-    if (!(key in currentSettings)) return;
-
-    const userPrompt = currentSettings[key];
     const defaultPrompt = CONFIG[key];
 
-    // Only update if versions differ OR if user somehow has a missing/invalid prompt
-    if (forceUpdatePrompts || userPrompt !== defaultPrompt) {
-      // If forceUpdatePrompts is false but prompts differ, it means the user 
-      // likely customized it, so we SHOULD NOT overwrite unless forceUpdatePrompts is true.
-      if (forceUpdatePrompts || !userPrompt) {
-        updates[key] = defaultPrompt;
-        migrationLog.push(`Updated prompt template ${key} to version ${targetPromptsVersion}`);
-      }
+    // Safety check: skip if key doesn't exist in CONFIG
+    if (defaultPrompt === undefined) {
+      logger.warn(`Prompt key ${key} is defined in registry but missing in CONFIG.`);
+      return;
     }
+
+    // 1. If key is completely missing in user settings, add it
+    if (!(key in currentSettings)) {
+      updates[key] = defaultPrompt;
+      migrationLog.push(`Added missing prompt setting: ${key}`);
+      return;
+    }
+
+    const userPrompt = currentSettings[key];
+
+    // 2. If stored prompt is empty or null, restore it to current default
+    if (!userPrompt || userPrompt.toString().trim() === '') {
+      updates[key] = defaultPrompt;
+      migrationLog.push(`Restored empty/missing prompt ${key} to default`);
+      return;
+    }
+
+    // 3. If stored prompt exactly matches current default, leave it
+    if (userPrompt === defaultPrompt) {
+      return;
+    }
+
+    // 4. If stored prompt matches a known historical default, upgrade to current default
+    const historicals = HISTORICAL_PROMPT_DEFAULTS[key] || [];
+    const isHistorical = historicals.some(hist => hist === userPrompt);
+    
+    if (isHistorical) {
+      updates[key] = defaultPrompt;
+      migrationLog.push(`Upgraded legacy default prompt ${key} to latest version`);
+      return;
+    }
+
+    // 5. Otherwise, treat as user-customized and preserve
+    logger.debug(`Preserved user customized prompt: ${key}`);
   });
 
-  // Ensure PROMPTS_VERSION is updated in storage
-  if (forceUpdatePrompts) {
+  // Ensure PROMPTS_VERSION is updated in storage as metadata
+  if (targetPromptsVersion > currentPromptsVersion) {
     updates.PROMPTS_VERSION = targetPromptsVersion;
   }
 

--- a/src/shared/config/settingsMigrations.js
+++ b/src/shared/config/settingsMigrations.js
@@ -195,8 +195,6 @@ function runMainMigration(currentSettings) {
   });
 
   // C. Handle prompt templates - safe update using historical defaults
-  const currentPromptsVersion = currentSettings.PROMPTS_VERSION || 1;
-  const targetPromptsVersion = CONFIG.PROMPTS_VERSION || 1;
 
   PROMPT_TEMPLATES.forEach(key => {
     const defaultPrompt = CONFIG[key];
@@ -245,11 +243,6 @@ function runMainMigration(currentSettings) {
     // 5. Otherwise, treat as user-customized and preserve
     logger.debug(`Preserved user customized prompt: ${key}`);
   });
-
-  // Ensure PROMPTS_VERSION is updated in storage as metadata
-  if (targetPromptsVersion > currentPromptsVersion) {
-    updates.PROMPTS_VERSION = targetPromptsVersion;
-  }
 
   // D. Synchronize Option Lists
   OPTION_LISTS.forEach(key => {

--- a/src/shared/config/settingsMigrations.js
+++ b/src/shared/config/settingsMigrations.js
@@ -1,91 +1,28 @@
 /**
  * Settings Migration System
- * 
- * Registry of historical default prompt templates used for safe prompt migrations.
  *
- * If a user's prompt matches one of these historical defaults, it is assumed
- * that the prompt was never customized and can be safely upgraded to the
- * latest CONFIG default.
+ * Handles automatic migrations for user settings when the extension is updated.
  *
- * Migration rules:
- * - Missing prompt -> replaced with current CONFIG default.
- * - Empty prompt -> replaced with current CONFIG default.
- * - Historical default -> upgraded to current CONFIG default.
- * - Any other value -> treated as a user customization and preserved.
+ * Responsibilities:
+ * 1. Add newly introduced settings with their default values.
+ * 2. Migrate legacy setting formats and keys.
+ * 3. Synchronize configuration-driven option lists.
+ * 4. Apply safe prompt template migrations.
+ * 5. Preserve user data, API keys, history, and customizations.
  *
- * IMPORTANT:
- * Whenever a default prompt template is changed in CONFIG, the previous
- * default value MUST be added to the corresponding array below.
+ * Prompt migration details and historical prompt defaults are maintained in:
+ *   promptHistoricalDefaults.js
  *
- * Example:
- *
- * Before:
- * CONFIG.PROMPT_TEMPLATE = "Prompt A"
- *
- * After:
- * CONFIG.PROMPT_TEMPLATE = "Prompt B"
- *
- * Add:
- * HISTORICAL_PROMPT_DEFAULTS.PROMPT_TEMPLATE.push("Prompt A")
- *
- * This allows users who still have the old unmodified default to receive
- * the new version automatically, while preserving customized prompts.
- *
- * Versioning Notes:
- * - Keep historical defaults grouped by release/version when possible.
- * - Do not remove old entries unless you are certain no supported upgrade
- *   path can reference them anymore.
- * - Users may upgrade across multiple versions, so migrations must support
- *   direct upgrades from older releases.
- *
- * Example:
- *
- * PROMPT_TEMPLATE: [
- *   // v1.17.0 default
- *   "Prompt A",
- *
- *   // v1.18.0 default
- *   "Prompt B"
- * ]
- *
- * NOTE:
- * PROMPTS_VERSION must not be used to force-overwrite prompt templates.
- * User customizations must always be preserved.
+ * Migration is executed during extension update and settings import flows.
  */
 
 import { CONFIG, TranslationMode } from './config.js';
 import { PROMPT_REGISTRY } from './PromptRegistry.js';
+import { HISTORICAL_PROMPT_DEFAULTS } from './promptHistoricalDefaults.js';
 import { getScopedLogger } from '@/shared/logging/logger.js';
 import { LOG_COMPONENTS } from '@/shared/logging/logConstants.js';
 
 const logger = getScopedLogger(LOG_COMPONENTS.CONFIG, 'SettingsMigrations');
-
-/**
- * Registry of historical default prompt templates to identify unmodified user prompts.
- * If a user's prompt matches one of these, it means they never customized it, 
- * so it is safe to auto-upgrade to the latest default template.
- */
-export const HISTORICAL_PROMPT_DEFAULTS = {
-  // Example:
-  // PROMPT_TEMPLATE: [
-  // v1.17.0 default
-  //   `Old prompt...`,
-  //
-  // v1.18.0 default
-  //   `Previous prompt...`
-  // ],
-  //
-  // When changing a default prompt in CONFIG, add the previous
-  // default value here before replacing it.
-
-  PROMPT_TEMPLATE: [],
-  PROMPT_TEMPLATE_AUTO: [],
-  PROMPT_BASE_FIELD: [],
-  PROMPT_BASE_FIELD_AUTO: [],
-  PROMPT_BASE_POPUP_TRANSLATE: [],
-  PROMPT_BASE_DICTIONARY: [],
-  PROMPT_SUBTITLE_USER: []
-};
 
 /**
  * Migrate MODE_PROVIDERS keys from old format (underscore) to new format (hyphenated/MessageContexts)
@@ -293,7 +230,11 @@ function runMainMigration(currentSettings) {
 
     // 4. If stored prompt matches a known historical default, upgrade to current default
     const historicals = HISTORICAL_PROMPT_DEFAULTS[key] || [];
-    const isHistorical = historicals.some(hist => hist === userPrompt);
+    const isHistorical = historicals.some(entry =>
+      typeof entry === 'string'
+        ? entry === userPrompt
+        : entry?.value === userPrompt
+    );
     
     if (isHistorical) {
       updates[key] = defaultPrompt;

--- a/src/shared/config/settingsMigrations.test.js
+++ b/src/shared/config/settingsMigrations.test.js
@@ -160,17 +160,14 @@ describe('Settings Migrations', () => {
     }
   });
 
-  it('should preserve customized prompt even if prompts version increases', async () => {
+  it('should preserve customized prompt during migration', async () => {
     const customPrompt = 'My custom customized prompt $_{SOURCE} $_{TARGET} $_{TEXT}';
     const currentSettings = {
-      PROMPT_TEMPLATE: customPrompt,
-      PROMPTS_VERSION: (CONFIG.PROMPTS_VERSION || 1) - 1
+      PROMPT_TEMPLATE: customPrompt
     };
 
     const { updates } = await runSettingsMigrations(currentSettings);
     // Custom template must be preserved (not overwritten/reverted)
     expect(updates.PROMPT_TEMPLATE).toBeUndefined();
-    // But metadata version should still be updated
-    expect(updates.PROMPTS_VERSION).toBe(CONFIG.PROMPTS_VERSION);
   });
 });

--- a/src/shared/config/settingsMigrations.test.js
+++ b/src/shared/config/settingsMigrations.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
-import { runSettingsMigrations } from './settingsMigrations.js';
+import { runSettingsMigrations, HISTORICAL_PROMPT_DEFAULTS } from './settingsMigrations.js';
 import { CONFIG, TranslationMode } from './config.js';
 
 // Mock logger
@@ -50,29 +50,6 @@ describe('Settings Migrations', () => {
     expect(logs.some(l => l.includes('Reset GEMINI_MODEL'))).toBe(true);
   });
 
-  it('should NOT update prompt templates if version is same', async () => {
-    const customPrompt = 'My custom prompt $_{TEXT}';
-    const currentSettings = {
-      PROMPT_TEMPLATE: customPrompt,
-      PROMPTS_VERSION: CONFIG.PROMPTS_VERSION
-    };
-    
-    const { updates } = await runSettingsMigrations(currentSettings);
-    expect(updates.PROMPT_TEMPLATE).toBeUndefined();
-  });
-
-  it('should FORCE update prompt templates if version increases', async () => {
-    const customPrompt = 'My custom prompt $_{TEXT}';
-    const currentSettings = {
-      PROMPT_TEMPLATE: customPrompt,
-      PROMPTS_VERSION: (CONFIG.PROMPTS_VERSION || 1) - 1
-    };
-    
-    const { updates, logs } = await runSettingsMigrations(currentSettings);
-    expect(updates.PROMPT_TEMPLATE).toBe(CONFIG.PROMPT_TEMPLATE);
-    expect(logs.some(l => l.includes('Updated prompt template'))).toBe(true);
-  });
-
   it('should migrate API_KEY to GEMINI_API_KEY', async () => {
     const currentSettings = {
       API_KEY: 'my-old-key',
@@ -93,5 +70,77 @@ describe('Settings Migrations', () => {
     
     const { updates } = await runSettingsMigrations(currentSettings);
     expect(updates.translationHistory).toBeUndefined(); // Should not be in updates (no change)
+  });
+
+  // --- Safe Prompt Migration Tests ---
+
+  it('should add current default when prompt key is missing', async () => {
+    const currentSettings = {
+      THEME: 'light'
+    };
+    // Ensure PROMPT_TEMPLATE is missing in currentSettings
+    delete currentSettings.PROMPT_TEMPLATE;
+
+    const { updates, logs } = await runSettingsMigrations(currentSettings);
+    expect(updates.PROMPT_TEMPLATE).toBe(CONFIG.PROMPT_TEMPLATE);
+    expect(logs).toContain('Added missing prompt setting: PROMPT_TEMPLATE');
+  });
+
+  it('should restore current default when prompt template is empty', async () => {
+    const currentSettings = {
+      PROMPT_TEMPLATE: '   '
+    };
+
+    const { updates, logs } = await runSettingsMigrations(currentSettings);
+    expect(updates.PROMPT_TEMPLATE).toBe(CONFIG.PROMPT_TEMPLATE);
+    expect(logs.some(l => l.includes('Restored empty/missing prompt PROMPT_TEMPLATE to default'))).toBe(true);
+  });
+
+  it('should leave prompt unchanged when it exactly matches current default', async () => {
+    const currentSettings = {
+      PROMPT_TEMPLATE: CONFIG.PROMPT_TEMPLATE
+    };
+
+    const { updates } = await runSettingsMigrations(currentSettings);
+    expect(updates.PROMPT_TEMPLATE).toBeUndefined();
+  });
+
+  it('should migrate historical legacy defaults to current default', async () => {
+    // Add a temporary mock historical default to test matching
+    const testOldDefault = 'legacy old default template _{SOURCE} _{TARGET} _{TEXT}';
+    if (!HISTORICAL_PROMPT_DEFAULTS.PROMPT_TEMPLATE) {
+      HISTORICAL_PROMPT_DEFAULTS.PROMPT_TEMPLATE = [];
+    }
+    HISTORICAL_PROMPT_DEFAULTS.PROMPT_TEMPLATE.push(testOldDefault);
+
+    try {
+      const currentSettings = {
+        PROMPT_TEMPLATE: testOldDefault
+      };
+
+      const { updates, logs } = await runSettingsMigrations(currentSettings);
+      expect(updates.PROMPT_TEMPLATE).toBe(CONFIG.PROMPT_TEMPLATE);
+      expect(logs.some(l => l.includes('Upgraded legacy default prompt PROMPT_TEMPLATE to latest version'))).toBe(true);
+    } finally {
+      // Clean up to ensure test isolation
+      const index = HISTORICAL_PROMPT_DEFAULTS.PROMPT_TEMPLATE.indexOf(testOldDefault);
+      if (index > -1) {
+        HISTORICAL_PROMPT_DEFAULTS.PROMPT_TEMPLATE.splice(index, 1);
+      }
+    }
+  });
+
+  it('should preserve customized prompt even if prompts version increases', async () => {
+    const customPrompt = 'My custom customized prompt $_{SOURCE} $_{TARGET} $_{TEXT}';
+    const currentSettings = {
+      PROMPT_TEMPLATE: customPrompt,
+      PROMPTS_VERSION: (CONFIG.PROMPTS_VERSION || 1) - 1
+    };
+
+    const { updates } = await runSettingsMigrations(currentSettings);
+    // Custom template must be preserved (not overwritten/reverted)
+    expect(updates.PROMPT_TEMPLATE).toBeUndefined();
+    // But metadata version should still be updated
+    expect(updates.PROMPTS_VERSION).toBe(CONFIG.PROMPTS_VERSION);
   });
 });

--- a/src/shared/config/settingsMigrations.test.js
+++ b/src/shared/config/settingsMigrations.test.js
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
-import { runSettingsMigrations, HISTORICAL_PROMPT_DEFAULTS } from './settingsMigrations.js';
+import { runSettingsMigrations } from './settingsMigrations.js';
+import { HISTORICAL_PROMPT_DEFAULTS } from './promptHistoricalDefaults.js';
 import { CONFIG, TranslationMode } from './config.js';
 
 // Mock logger
@@ -105,7 +106,7 @@ describe('Settings Migrations', () => {
     expect(updates.PROMPT_TEMPLATE).toBeUndefined();
   });
 
-  it('should migrate historical legacy defaults to current default', async () => {
+  it('should migrate historical legacy defaults (string format) to current default', async () => {
     // Add a temporary mock historical default to test matching
     const testOldDefault = 'legacy old default template _{SOURCE} _{TARGET} _{TEXT}';
     if (!HISTORICAL_PROMPT_DEFAULTS.PROMPT_TEMPLATE) {
@@ -124,6 +125,35 @@ describe('Settings Migrations', () => {
     } finally {
       // Clean up to ensure test isolation
       const index = HISTORICAL_PROMPT_DEFAULTS.PROMPT_TEMPLATE.indexOf(testOldDefault);
+      if (index > -1) {
+        HISTORICAL_PROMPT_DEFAULTS.PROMPT_TEMPLATE.splice(index, 1);
+      }
+    }
+  });
+
+  it('should migrate historical legacy defaults (object format) to current default', async () => {
+    // Add a temporary mock historical default in object format to test matching
+    const testOldDefaultObj = {
+      version: 'v1.17.0',
+      reason: 'Legacy default to migrate',
+      value: 'legacy old default template in object format _{SOURCE} _{TARGET} _{TEXT}'
+    };
+    if (!HISTORICAL_PROMPT_DEFAULTS.PROMPT_TEMPLATE) {
+      HISTORICAL_PROMPT_DEFAULTS.PROMPT_TEMPLATE = [];
+    }
+    HISTORICAL_PROMPT_DEFAULTS.PROMPT_TEMPLATE.push(testOldDefaultObj);
+
+    try {
+      const currentSettings = {
+        PROMPT_TEMPLATE: testOldDefaultObj.value
+      };
+
+      const { updates, logs } = await runSettingsMigrations(currentSettings);
+      expect(updates.PROMPT_TEMPLATE).toBe(CONFIG.PROMPT_TEMPLATE);
+      expect(logs.some(l => l.includes('Upgraded legacy default prompt PROMPT_TEMPLATE to latest version'))).toBe(true);
+    } finally {
+      // Clean up to ensure test isolation
+      const index = HISTORICAL_PROMPT_DEFAULTS.PROMPT_TEMPLATE.indexOf(testOldDefaultObj);
       if (index > -1) {
         HISTORICAL_PROMPT_DEFAULTS.PROMPT_TEMPLATE.splice(index, 1);
       }


### PR DESCRIPTION
## Summary

Improves prompt template handling and settings persistence by introducing safe prompt migrations and partial-save support for invalid prompt templates.

Previously:

* Any prompt validation error blocked the entire save operation.
* Updating default prompt templates required `PROMPTS_VERSION`, which either left users on outdated defaults or risked overwriting customized prompts.

This PR resolves both issues by preserving user customizations during prompt migrations and allowing valid settings to be saved even when prompt template validation fails.

## Key Changes

### Options Save Experience

* Added partial-save support for prompt-only validation failures.
* Invalid prompt templates are excluded from persistence while valid settings continue to save normally.
* Preserves invalid prompt drafts in the editor so users can continue editing without losing their changes.
* Added a warning status message (`OPTIONS_STATUS_SAVED_WITH_PROMPT_ERRORS`) to clearly indicate that settings were saved but invalid prompt templates were skipped.
* Improved validation feedback by preventing silent save failures and providing explicit user-facing status messages.
* Refactored post-save notification logic into a shared helper to avoid duplication.

### Safe Prompt Migrations

* Replaced version-based prompt migrations with content-based historical default detection.
* Added a dedicated `promptHistoricalDefaults.js` registry for tracking legacy prompt defaults.
* Prompt templates that still match a historical default are automatically upgraded to the latest default.
* User-customized prompt templates are preserved and never overwritten during migrations.
* Added comprehensive maintenance documentation describing how future prompt default updates should be handled.
* Added backward compatibility support for both legacy string entries and structured historical prompt entries.

### Cleanup

* Removed the obsolete `PROMPTS_VERSION` migration mechanism.
* Simplified migration logic by relying entirely on historical default matching.

## Testing

Added and updated test coverage for:

* Successful saves with valid settings.
* Partial-save behavior when prompt templates are invalid.
* Full save blocking when non-prompt validation errors are present.
* Draft restoration after save completion or failure.
* Migration of historical prompt defaults (string format).
* Migration of historical prompt defaults (object format).
* Preservation of customized prompt templates during migrations.
* Restoration of missing or empty prompt templates to current defaults.

Refs: #147
