### PR TITLE
fix(context-menu): refresh provider list on visibility changes

### DIFF
--- a/src/core/managers/context-menu.js
+++ b/src/core/managers/context-menu.js
@@ -997,7 +997,8 @@ export class ContextMenuManager extends ResourceTracker {
             'MODE_PROVIDERS', 
             'EXTENSION_ENABLED', 
             'DEBUG_MODE', 
-            'CONTEXT_MENU_VISIBILITY'
+            'CONTEXT_MENU_VISIBILITY',
+            'HIDDEN_PROVIDERS'
           ];
           
           const isRelevantChange = Object.keys(changes).some(key => 


### PR DESCRIPTION
## Summary

Fix browser Action context-menu provider list not updating after provider visibility settings change.

## Root Cause

`HIDDEN_PROVIDERS` was missing from `ContextMenuManager` storage `relevantKeys`.

Storage changes were persisted correctly, but context menus were not rebuilt until extension reload.

## Changes

* Add `HIDDEN_PROVIDERS` to context-menu relevant storage keys.
* Reuse existing menu refresh flow.
* No new listeners, events, or state.

## Verification

* Provider hide/show changes refresh Action menu without reload.
* Existing active-provider behavior remains unchanged.
* ESLint passed.
* `git diff --check` passed.
