### PR TITLE
chore: update pnpm to 11.21.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -104,5 +104,5 @@
     "webextension-polyfill": "^0.12.0",
     "xss": "^1.0.15"
   },
-  "packageManager": "pnpm@11.9.0"
+  "packageManager": "pnpm@11.21.0"
 }


### PR DESCRIPTION
## Summary

Update project package manager version from pnpm 11.9.0 to 11.21.0.

## Changes

- Update `packageManager` in `package.json` to `pnpm@11.21.0`.
- No dependency or application code changes.