### PR TITLE
fix(select-element): harden transactional mutation rollback

### DIFF
--- a/src/features/element-selection/core/BlockGroupReconstructor.test.js
+++ b/src/features/element-selection/core/BlockGroupReconstructor.test.js
@@ -187,6 +187,36 @@ describe('BlockGroupReconstructor', () => {
       expect(textNodes[0].nodeValue).toBe('Hello ');
     });
 
+    it('continues restoring remaining segments and surfaces rollback failures', () => {
+      const originalSecond = textNodes[1].nodeValue;
+      let writes = 0;
+      Object.defineProperty(textNodes[1], 'nodeValue', {
+        configurable: true,
+        get: () => originalSecond,
+        set: () => {
+          writes += 1;
+          if (writes === 1) throw 'mutation-failure';
+          throw 'restore-failure';
+        }
+      });
+
+      let failure;
+      try {
+        BlockGroupReconstructor.apply(units, 'Uno @@SEG_n2@@Dos@@SEG_n3@@Tres', 'fa', document.body);
+      } catch (error) {
+        failure = error;
+      }
+
+      expect(failure).toBeInstanceOf(BlockGroupMutationFailure);
+      expect(failure.cause).toBe('mutation-failure');
+      expect(failure.rollbackFailures).toEqual([
+        expect.objectContaining({ kind: 'text', id: 'n2', error: 'restore-failure' })
+      ]);
+      expect(textNodes[0].nodeValue).toBe('Hello ');
+      expect(textNodes[1].nodeValue).toBe('world');
+      expect(textNodes[2].nodeValue).toBe('.');
+    });
+
     it('preserves pre-existing translating class on success and failure', () => {
       const parent = textNodes[0].parentElement;
       parent.classList.add('ti-translating');

--- a/src/features/element-selection/core/DomTranslatorAdapter.js
+++ b/src/features/element-selection/core/DomTranslatorAdapter.js
@@ -57,8 +57,9 @@ export { getSelectElementTranslationState, revertSelectElementTranslation } from
 const activeTranslationRoots = new Set();
 
 class DirectMutationFailure {
-  constructor(cause) {
+  constructor(cause, rollbackFailures = []) {
     this.cause = cause;
+    this.rollbackFailures = rollbackFailures;
   }
 }
 
@@ -436,10 +437,12 @@ export class DomTranslatorAdapter extends ResourceTracker {
           parent.invalid = true;
           parent.applied = false;
           parent.acknowledged = false;
+          const rollbackFailures = [];
           for (const { node, value } of [...mutationSnapshot.nodes].reverse()) {
             try {
               if (node) node.nodeValue = value;
             } catch (rollbackError) {
+              rollbackFailures.push({ kind: 'text', node, error: rollbackError });
               this.logger.error('[DomTranslatorAdapter] Direct text rollback failed', { error: rollbackError });
             }
           }
@@ -448,11 +451,13 @@ export class DomTranslatorAdapter extends ResourceTracker {
               if (state.present) parentElement.setAttribute(PAGE_TRANSLATION_ATTRIBUTES.HAS_ORIGINAL, state.value);
               else parentElement.removeAttribute(PAGE_TRANSLATION_ATTRIBUTES.HAS_ORIGINAL);
             } catch (rollbackError) {
+              rollbackFailures.push({ kind: 'attribute', element: parentElement, error: rollbackError });
               this.logger.error('[DomTranslatorAdapter] Direct attribute rollback failed', { error: rollbackError });
             }
           }
           const directionFailures = DirectionManager.restoreNodeDirectionState(mutationSnapshot.directionSnapshots) || [];
           for (const failure of directionFailures) {
+            rollbackFailures.push(failure);
             this.logger.error('[DomTranslatorAdapter] Direct direction rollback failed', failure);
           }
           for (const { node, value } of mutationSnapshot.hoverNodes) {
@@ -460,10 +465,15 @@ export class DomTranslatorAdapter extends ResourceTracker {
               if (value === undefined) hoverPreviewLookup.delete(node);
               else hoverPreviewLookup.add(node, value);
             } catch (rollbackError) {
+              rollbackFailures.push({ kind: 'hover', node, error: rollbackError });
               this.logger.error('[DomTranslatorAdapter] Direct hover rollback failed', { error: rollbackError });
             }
           }
-          throw new DirectMutationFailure(error);
+          // Mutation failure lifecycle: best-effort rollback performed above, then
+          // emit a rejection ACK for the failed canonical parent so the background
+          // coordinator marks it REJECTED (never left PENDING blocking later parents).
+          this._sendParentAcceptanceAck(parent.parentId, null, false, translationToken).catch(() => {});
+          throw new DirectMutationFailure(error, rollbackFailures);
         }
       };
 
@@ -506,9 +516,18 @@ export class DomTranslatorAdapter extends ResourceTracker {
       };
 
       const finalizeDirectParents = (targetLanguage, translationToken) => {
+        // Independent canonical parents: a mutation failure in one parent must
+        // not prevent remaining parents from committing. Preserve the first
+        // failure and rethrow after all parents have been attempted.
+        let firstFailure = null;
         for (const parent of directParentStates.values()) {
-          applyCompleteDirectParent(parent, targetLanguage, translationToken);
+          try {
+            applyCompleteDirectParent(parent, targetLanguage, translationToken);
+          } catch (error) {
+            if (!firstFailure) firstFailure = error;
+          }
         }
+        if (firstFailure) throw firstFailure;
       };
 
       // Context

--- a/src/features/element-selection/core/DomTranslatorAdapter.test.js
+++ b/src/features/element-selection/core/DomTranslatorAdapter.test.js
@@ -623,6 +623,52 @@ describe('DomTranslatorAdapter', () => {
       expect(adapter.groupMap.get('g2').applied).toBe(false);
     });
 
+    it('keeps an already-committed group when a later independent group mutation fails', async () => {
+      const { getFeatureSemanticBlockGroupingAsync } = await import('@/config.js');
+      getFeatureSemanticBlockGroupingAsync.mockResolvedValueOnce(true);
+      const first = document.createTextNode('A');
+      const second = document.createTextNode('B');
+      testElement.replaceChildren(first, second);
+      const { collectBlockGroups } = await import('./DomTranslatorUtils.js');
+      collectBlockGroups.mockReturnValueOnce([
+        { id: 'n1', blockId: 'g1', text: 'A', leadingWS: '', trailingWS: '', preWhitespace: false, directionHint: 'ltr', inlineParentTags: ['div'], mode: 'standard', node: first },
+        { id: 'n2', blockId: 'g2', text: 'B', leadingWS: '', trailingWS: '', preWhitespace: false, directionHint: 'ltr', inlineParentTags: ['div'], mode: 'standard', node: second },
+      ]);
+      const { BlockGroupReconstructor } = await import('./BlockGroupReconstructor.js');
+      const realApply = BlockGroupReconstructor.apply;
+      const applySpy = vi.spyOn(BlockGroupReconstructor, 'apply')
+        .mockImplementationOnce((...args) => realApply.call(BlockGroupReconstructor, ...args))
+        .mockImplementationOnce(() => { throw new Error('group2 mutation failed'); });
+      let callbacks;
+      registerTranslation.mockImplementationOnce((_id, registered) => { callbacks = registered; });
+      contentScriptIntegration.sendTranslationRequest.mockResolvedValueOnce({
+        success: true,
+        streaming: true,
+        conversationAcceptance: true,
+      });
+
+      const translation = adapter.translateElement(testElement);
+      await vi.waitFor(() => expect(callbacks).toBeDefined());
+      callbacks.onStreamUpdate({ success: true, data: [{ t: 'Uno', i: 'n1' }, { t: 'Dos', i: 'n2' }] });
+      callbacks.onStreamEnd({ success: true });
+
+      await expect(translation).rejects.toThrow('group2 mutation failed');
+      applySpy.mockRestore();
+      expect(first.nodeValue).toContain('Uno');
+      expect(second.nodeValue).toBe('B');
+
+      const accepted = sendRegularMessage.mock.calls
+        .map(([message]) => message?.data)
+        .filter(data => data?.accepted === true)
+        .map(data => data.parentId);
+      const rejected = sendRegularMessage.mock.calls
+        .map(([message]) => message?.data)
+        .filter(data => data?.accepted === false)
+        .map(data => data.parentId);
+      expect(accepted).toEqual(['g1']);
+      expect(rejected).toEqual(['g2']);
+    });
+
     it('reports PARTIAL_SUCCESS with one committed group and one invalid V2 passthrough group', async () => {
       const { getFeatureSemanticBlockGroupingAsync } = await import('@/config.js');
       getFeatureSemanticBlockGroupingAsync.mockResolvedValueOnce(true);
@@ -2569,6 +2615,240 @@ describe('DomTranslatorAdapter', () => {
       await expect(adapter.translateElement(testElement)).rejects.toThrow('hover rollback failure');
       expect(lookup.has(first)).toBe(false);
       expect(lookup.has(second)).toBe(false);
+    });
+
+    it('emits one rejection ACK on direct mutation failure and never a positive ACK', async () => {
+      const textNode = testElement.firstChild;
+      const { collectTextNodes } = await import('./DomTranslatorUtils.js');
+      collectTextNodes.mockReturnValueOnce([
+        { node: textNode, text: 'Hello', uid: 'n1', blockId: 'b1', role: 'div' }
+      ]);
+      vi.spyOn(adapter, '_applyTranslationToNode').mockImplementationOnce(() => {
+        throw new Error('mutation failure');
+      });
+      contentScriptIntegration.sendTranslationRequest.mockResolvedValueOnce({
+        success: true,
+        streaming: false,
+        translatedText: [{ t: 'Uno', i: 'n1' }],
+        conversationAcceptance: true,
+      });
+
+      await expect(adapter.translateElement(testElement)).rejects.toThrow('mutation failure');
+
+      const ackCalls = sendRegularMessage.mock.calls
+        .map(([message]) => message?.data)
+        .filter(data => data?.parentId === 'b1');
+      expect(ackCalls).toEqual([
+        expect.objectContaining({ parentId: 'b1', accepted: false })
+      ]);
+      expect(textNode.nodeValue).toBe('Hello');
+    });
+
+    it('aggregates direct rollback failures while preserving the original mutation error', async () => {
+      const first = document.createTextNode('A');
+      const second = document.createTextNode('B');
+      testElement.replaceChildren(first, second);
+      const { collectTextNodes } = await import('./DomTranslatorUtils.js');
+      collectTextNodes.mockReturnValueOnce([
+        { node: first, text: 'A', uid: 'n1', blockId: 'b1', role: 'div' },
+        { node: second, text: 'B', uid: 'n2', blockId: 'b1', role: 'div' }
+      ]);
+      let streamCallbacks;
+      registerTranslation.mockImplementationOnce((_id, callbacks) => { streamCallbacks = callbacks; });
+      contentScriptIntegration.sendTranslationRequest.mockResolvedValueOnce({
+        success: true,
+        streaming: true,
+        conversationAcceptance: true,
+      });
+      const { applyNodeDirection, restoreNodeDirectionState } = await import('@/utils/dom/DomDirectionManager.js');
+      vi.spyOn(adapter, '_applyTranslationToNode')
+        .mockImplementationOnce((...args) => DomTranslatorAdapter.prototype._applyTranslationToNode.call(adapter, ...args))
+        .mockImplementationOnce(() => { throw new Error('second node mutation failed'); });
+      applyNodeDirection.mockImplementation(() => {});
+      restoreNodeDirectionState.mockReturnValueOnce([
+        { kind: 'style', name: 'direction', error: new Error('direction restore failed') }
+      ]);
+
+      const translation = adapter.translateElement(testElement);
+      await vi.waitFor(() => expect(streamCallbacks).toBeDefined());
+      streamCallbacks.onStreamUpdate({ success: true, data: [{ t: 'Uno', i: 'n1' }, { t: 'Dos', i: 'n2' }] });
+      streamCallbacks.onStreamEnd({ success: true });
+
+      const rejection = await translation.catch(error => error);
+      expect(rejection.cause).toBeInstanceOf(Object);
+      expect(rejection.cause.rollbackFailures).toEqual([
+        expect.objectContaining({ kind: 'style', name: 'direction' })
+      ]);
+      expect(rejection.cause.cause?.message).toBe('second node mutation failed');
+      expect(first.nodeValue).toBe('A');
+      expect(second.nodeValue).toBe('B');
+      const b1Acks = sendRegularMessage.mock.calls
+        .map(([message]) => message)
+        .filter(message => message?.data?.parentId === 'b1');
+      expect(b1Acks).toEqual([
+        expect.objectContaining({ data: expect.objectContaining({ accepted: false }) })
+      ]);
+    });
+
+    it('continues text restorations past a failing restore and preserves the primary mutation error', async () => {
+      const first = document.createTextNode('A');
+      const second = document.createTextNode('B');
+      const third = document.createTextNode('C');
+      testElement.replaceChildren(first, second, third);
+      const originalSecond = second.nodeValue;
+      let currentSecond = originalSecond;
+      let secondWrites = 0;
+      Object.defineProperty(second, 'nodeValue', {
+        configurable: true,
+        get: () => currentSecond,
+        set: (value) => {
+          secondWrites += 1;
+          if (secondWrites > 1) throw new Error('text rollback failure');
+          currentSecond = value;
+        }
+      });
+      const { collectTextNodes } = await import('./DomTranslatorUtils.js');
+      collectTextNodes.mockReturnValueOnce([
+        { node: first, text: 'A', uid: 'n1', blockId: 'b1', role: 'div' },
+        { node: second, text: 'B', uid: 'n2', blockId: 'b1', role: 'div' },
+        { node: third, text: 'C', uid: 'n3', blockId: 'b1', role: 'div' }
+      ]);
+      let streamCallbacks;
+      registerTranslation.mockImplementationOnce((_id, callbacks) => { streamCallbacks = callbacks; });
+      contentScriptIntegration.sendTranslationRequest.mockResolvedValueOnce({
+        success: true,
+        streaming: true,
+        conversationAcceptance: true,
+      });
+      vi.spyOn(adapter, '_applyTranslationToNode')
+        .mockImplementationOnce((...args) => DomTranslatorAdapter.prototype._applyTranslationToNode.call(adapter, ...args))
+        .mockImplementationOnce((...args) => DomTranslatorAdapter.prototype._applyTranslationToNode.call(adapter, ...args))
+        .mockImplementationOnce(() => { throw new Error('primary mutation failure'); });
+
+      const translation = adapter.translateElement(testElement);
+      await vi.waitFor(() => expect(streamCallbacks).toBeDefined());
+      streamCallbacks.onStreamUpdate({ success: true, data: [{ t: 'Uno', i: 'n1' }, { t: 'Dos', i: 'n2' }, { t: 'Tres', i: 'n3' }] });
+      streamCallbacks.onStreamEnd({ success: true });
+
+      const rejection = await translation.catch(error => error);
+      expect(rejection.cause.cause?.message).toBe('primary mutation failure');
+      expect(rejection.cause.rollbackFailures).toEqual([
+        expect.objectContaining({ kind: 'text', node: second, error: expect.objectContaining({ message: 'text rollback failure' }) })
+      ]);
+      expect(third.nodeValue).toBe('C');
+      expect(first.nodeValue).toBe('A');
+      expect(second.nodeValue).toContain('Dos');
+
+      const b1Acks = sendRegularMessage.mock.calls
+        .map(([message]) => message)
+        .filter(message => message?.data?.parentId === 'b1');
+      expect(b1Acks).toEqual([
+        expect.objectContaining({ data: expect.objectContaining({ accepted: false }) })
+      ]);
+    });
+
+    it('commits independent parents around a failed middle parent', async () => {
+      const first = document.createTextNode('A');
+      const second = document.createTextNode('B');
+      const third = document.createTextNode('C');
+      testElement.replaceChildren(first, second, third);
+      const { collectTextNodes } = await import('./DomTranslatorUtils.js');
+      collectTextNodes.mockReturnValueOnce([
+        { node: first, text: 'A', uid: 'n1', blockId: 'b1', role: 'div' },
+        { node: second, text: 'B', uid: 'n2', blockId: 'b2', role: 'div' },
+        { node: third, text: 'C', uid: 'n3', blockId: 'b3', role: 'div' }
+      ]);
+      vi.spyOn(adapter, '_applyTranslationToNode')
+        .mockImplementationOnce((...args) => DomTranslatorAdapter.prototype._applyTranslationToNode.call(adapter, ...args))
+        .mockImplementationOnce(() => { throw new Error('middle parent failed'); })
+        .mockImplementationOnce((...args) => DomTranslatorAdapter.prototype._applyTranslationToNode.call(adapter, ...args));
+      contentScriptIntegration.sendTranslationRequest.mockResolvedValueOnce({
+        success: true,
+        streaming: false,
+        translatedText: [
+          { t: 'Uno', i: 'n1' },
+          { t: 'Dos', i: 'n2' },
+          { t: 'Tres', i: 'n3' }
+        ],
+        conversationAcceptance: true,
+      });
+
+      await expect(adapter.translateElement(testElement)).rejects.toThrow('middle parent failed');
+      expect(first.nodeValue).toContain('Uno');
+      expect(second.nodeValue).toBe('B');
+      expect(third.nodeValue).toContain('Tres');
+
+      const accepted = sendRegularMessage.mock.calls
+        .map(([message]) => message?.data)
+        .filter(data => data?.accepted === true)
+        .map(data => data.parentId)
+        .sort();
+      const rejected = sendRegularMessage.mock.calls
+        .map(([message]) => message?.data)
+        .filter(data => data?.accepted === false)
+        .map(data => data.parentId)
+        .sort();
+      expect(accepted).toEqual(['b1', 'b3']);
+      expect(rejected).toEqual(['b2']);
+    });
+
+    it('removes introduced direction attributes when original dir was absent and rollback runs', async () => {
+      const textNode = testElement.firstChild;
+      const { collectTextNodes } = await import('./DomTranslatorUtils.js');
+      collectTextNodes.mockReturnValueOnce([
+        { node: textNode, text: 'Hello', uid: 'n1', blockId: 'b1', role: 'div' }
+      ]);
+      const realDir = await vi.importActual('@/utils/dom/DomDirectionManager.js');
+      const { applyNodeDirection, captureNodeDirectionState, restoreNodeDirectionState, detectDirectionFromContent } =
+        await import('@/utils/dom/DomDirectionManager.js');
+      applyNodeDirection.mockImplementationOnce((node, lang, root) => {
+        realDir.applyNodeDirection(node, lang, root);
+        throw new Error('direction state introduced before failure');
+      });
+      captureNodeDirectionState.mockImplementationOnce((node, root) => realDir.captureNodeDirectionState(node, root));
+      restoreNodeDirectionState.mockImplementationOnce((snapshots) => realDir.restoreNodeDirectionState(snapshots));
+      detectDirectionFromContent.mockReturnValue('rtl');
+      contentScriptIntegration.sendTranslationRequest.mockResolvedValueOnce({
+        success: true,
+        streaming: false,
+        translatedText: [{ t: 'سلام', i: 'n1' }],
+        conversationAcceptance: true,
+      });
+
+      await expect(adapter.translateElement(testElement)).rejects.toThrow('direction state introduced before failure');
+      expect(testElement.hasAttribute('data-translate-dir')).toBe(false);
+      expect(testElement.hasAttribute('data-dir-original-saved')).toBe(false);
+      expect(testElement.style.direction).toBe('');
+      expect(testElement.hasAttribute('dir')).toBe(false);
+    });
+
+    it('restores exact inline direction style value and priority on rollback', async () => {
+      testElement.style.setProperty('direction', 'ltr', 'important');
+      const textNode = testElement.firstChild;
+      const { collectTextNodes } = await import('./DomTranslatorUtils.js');
+      collectTextNodes.mockReturnValueOnce([
+        { node: textNode, text: 'Hello', uid: 'n1', blockId: 'b1', role: 'div' }
+      ]);
+      const realDir = await vi.importActual('@/utils/dom/DomDirectionManager.js');
+      const { applyNodeDirection, captureNodeDirectionState, restoreNodeDirectionState, detectDirectionFromContent } =
+        await import('@/utils/dom/DomDirectionManager.js');
+      applyNodeDirection.mockImplementationOnce((node, lang, root) => {
+        realDir.applyNodeDirection(node, lang, root);
+        throw new Error('style mutation failed');
+      });
+      captureNodeDirectionState.mockImplementationOnce((node, root) => realDir.captureNodeDirectionState(node, root));
+      restoreNodeDirectionState.mockImplementationOnce((snapshots) => realDir.restoreNodeDirectionState(snapshots));
+      detectDirectionFromContent.mockReturnValue('rtl');
+      contentScriptIntegration.sendTranslationRequest.mockResolvedValueOnce({
+        success: true,
+        streaming: false,
+        translatedText: [{ t: 'سلام', i: 'n1' }],
+        conversationAcceptance: true,
+      });
+
+      await expect(adapter.translateElement(testElement)).rejects.toThrow('style mutation failed');
+      expect(testElement.style.getPropertyValue('direction')).toBe('ltr');
+      expect(testElement.style.getPropertyPriority('direction')).toBe('important');
     });
 
     it.each([


### PR DESCRIPTION
## Summary

Hardens Select Element DOM mutation rollback and failure handling for both direct-parent and grouped translation paths.

Failed mutations are now rolled back on a best-effort basis without affecting independently committed parents, and failed direct parents are explicitly rejected so they cannot remain pending and block later commits.

## Changes

- Extend `DirectMutationFailure` with aggregated rollback failures.
- Send `accepted: false` for direct parents that fail during DOM mutation.
- Continue rollback attempts when an individual restoration fails.
- Preserve the original mutation error as the primary failure.
- Preserve rollback failures separately for diagnostics.
- Continue processing independent direct parents after one parent fails.
- Preserve already committed parents and BlockGroups when later mutations fail.
- Verify exact rollback of:
  - translated text
  - translation attributes
  - direction attributes
  - inline direction styles
  - CSS priority such as `!important`
  - hover state
- Strengthen grouped rollback regression coverage.

## Behavior

Direct parent lifecycle:

`mutation → failure → best-effort rollback → rejection ACK → error`

A failed parent no longer remains `PENDING`, while successfully committed independent parents remain translated.

Rollback failures do not replace the original mutation error and do not prevent remaining restoration attempts.

## Regression Coverage

Added coverage for:

- direct mutation rejection ACK
- text rollback failure aggregation
- continuation after a failed restoration
- independent parent commits around a failed parent
- rollback when the original `dir` attribute was absent
- exact restoration of inline direction style and priority
- independent BlockGroup commit/failure behavior
- grouped rollback failure aggregation
- separation of primary mutation and rollback errors

## Tests

- Select Element + translation/conversation regression suite: **502 passed, 0 failed**
- ESLint: passed
- `git diff --check`: passed

## Scope

No changes to providers, batching, extraction/traversal, optimization levels, AUTO language detection, translation protocol, conversation ownership, or global timeout semantics.