### PR TITLE
fix: reuse resolved AUTO language pair across translation batches

### DIFF
--- a/src/core/services/translation/UnifiedModeCoordinator.js
+++ b/src/core/services/translation/UnifiedModeCoordinator.js
@@ -402,6 +402,15 @@ export class UnifiedModeCoordinator {
 
       logger.debug(`[UnifiedCoordinator] ${mode} batch source: ${effectiveSourceLanguage}`);
 
+      // A Page waiter/established batch has a canonical session-resolved source.
+      // Pass languagePairResolved so ProviderCoordinator skips the semantic
+      // swap/detection that the session owner already performed. The owner (and
+      // every non-Page batch, e.g. Subtitle per-batch AUTO) stays unresolved.
+      const languagePairResolved = mode === TranslationMode.Page
+        && sourceLanguage === AUTO_DETECT_VALUE
+        && sourceResolution !== null
+        && sourceResolution.isOwner !== true;
+
       // Determine what to pass to the provider
       const translationPayload = useRawItems 
         ? items 
@@ -440,6 +449,7 @@ export class UnifiedModeCoordinator {
             instruction,
             rawJsonPayload: true,
             executionContext,
+            ...(languagePairResolved && { languagePairResolved: true }),
         }),
         timeoutPromise
       ]);

--- a/src/core/services/translation/UnifiedModeCoordinator.test.js
+++ b/src/core/services/translation/UnifiedModeCoordinator.test.js
@@ -300,9 +300,11 @@ describe('UnifiedModeCoordinator', () => {
     function deferredProvider() {
       return {
         sources: [],
+        options: [],
         pending: [],
         translate() {
           this.sources.push(arguments[1]);
+          this.options.push(arguments[3]);
           const next = deferred();
           this.pending.push(next);
           return next.promise;
@@ -358,6 +360,12 @@ describe('UnifiedModeCoordinator', () => {
         await flush();
 
         expect(provider.sources).toEqual(['auto', 'en', 'en']);
+
+        // Only the owner resolves the session source; established waiters pass
+        // languagePairResolved so ProviderCoordinator skips semantic swap/detect.
+        expect(provider.options[0].languagePairResolved).toBeUndefined();
+        expect(provider.options[1].languagePairResolved).toBe(true);
+        expect(provider.options[2].languagePairResolved).toBe(true);
 
         provider.pending[1].resolve(provider.success('en'));
         provider.pending[2].resolve(provider.success('en'));
@@ -561,6 +569,8 @@ describe('UnifiedModeCoordinator', () => {
         await flush();
         expect(provider.sources).toEqual(['de', 'de']);
         expect(coordinator.pageSourceResolvers.size).toBe(0);
+        // Explicit source is not semantic resolution: no languagePairResolved.
+        expect(provider.options.every((o) => o.languagePairResolved === undefined)).toBe(true);
 
         provider.pending[0].resolve(provider.success('de'));
         provider.pending[1].resolve(provider.success('de'));
@@ -586,6 +596,8 @@ describe('UnifiedModeCoordinator', () => {
         await flush();
         await flush();
         expect(provider.sources).toEqual(['auto', 'auto']);
+        // Subtitle keeps per-batch AUTO: never resolved at session level.
+        expect(provider.options.every((o) => o.languagePairResolved === undefined)).toBe(true);
 
         provider.pending[0].resolve(provider.success('de'));
         provider.pending[1].resolve(provider.success('de'));

--- a/src/features/translation/core/OperationSourceLanguageResolver.js
+++ b/src/features/translation/core/OperationSourceLanguageResolver.js
@@ -160,7 +160,9 @@ const getDetectionBypassDecision = (detection) => {
 
 /**
  * Resolve one operation's candidate source/target pair without scheduling it.
- * This is intentionally not wired into ProviderCoordinator or batch handlers.
+ * Consumed by OptimizedJsonHandler to gate AUTO first-batch translation:
+ * eligible resolutions bypass the sequential gate; denied resolutions retain
+ * the first-batch fallback (see LANGUAGE_DETECTION.md).
  */
 export const resolveOperationSourceLanguage = async ({
   text,

--- a/src/features/translation/core/managers/OptimizedJsonHandler.integration.test.js
+++ b/src/features/translation/core/managers/OptimizedJsonHandler.integration.test.js
@@ -1,0 +1,209 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Seam-level regression: OptimizedJsonHandler → real BaseProvider.translate →
+// real ProviderCoordinator.execute → real LanguageSwappingService →
+// LanguageDetectionService. The only stubs are the leaf boundaries that the
+// production system does not own deterministically:
+//   - OperationSourceLanguageResolver gate result (denied AUTO path)
+//   - LanguageDetectionService.detect return value (browser/statistical leaf)
+// provider.translate and ProviderCoordinator.execute are NOT mocked, so the
+// swap/detect guard under test runs through its real control flow.
+
+vi.mock('@/shared/logging/logger.js', () => ({
+  getScopedLogger: () => ({
+    init: vi.fn(),
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  }),
+}));
+
+vi.mock('@/features/translation/core/TranslationStatsManager.js', () => ({
+  statsManager: {
+    getSessionSummary: vi.fn(() => ({ chars: 100, originalChars: 80 })),
+    printSummary: vi.fn(),
+  },
+}));
+
+const resolveOperationSourceLanguage = vi.hoisted(() => vi.fn());
+
+vi.mock('@/features/translation/core/OperationSourceLanguageResolver.js', () => ({
+  resolveOperationSourceLanguage,
+}));
+
+vi.mock('@/shared/config/config.js', async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    // Bilingual toggles are mutable so each test pins its own state.
+    getBilingualTranslationEnabledAsync: vi.fn(),
+    getBilingualTranslationModesAsync: vi.fn(),
+    getAIConversationHistoryEnabledAsync: vi.fn().mockResolvedValue(false),
+    getProviderOptimizationLevelAsync: vi.fn().mockResolvedValue(3),
+    getSettingsAsync: vi.fn().mockResolvedValue({}),
+  };
+});
+
+import { OptimizedJsonHandler } from './OptimizedJsonHandler.js';
+import { BaseProvider } from '@/features/translation/providers/BaseProvider.js';
+import { LanguageSwappingService } from '@/features/translation/providers/LanguageSwappingService.js';
+import { LanguageDetectionService } from '@/shared/services/LanguageDetectionService.js';
+import { TranslationMode, getBilingualTranslationEnabledAsync, getBilingualTranslationModesAsync } from '@/shared/config/config.js';
+
+// 'select-element' is the real MessageContexts.SELECT_ELEMENT value that
+// TranslationMode.Select_Element maps to.
+const SELECT_ELEMENT_MODE = 'select-element';
+
+class RecordingProvider extends BaseProvider {
+  static batchStrategy = 'none';
+  static isAI = false;
+
+  constructor() {
+    super('IntegrationProvider');
+    this.batchCalls = [];
+  }
+
+  async _batchTranslate(texts, sourceLang, targetLang) {
+    this.batchCalls.push([sourceLang, targetLang, texts.slice()]);
+    return texts.map((text) => `[tr]${typeof text === 'object' ? (text.t ?? text.text) : text}`);
+  }
+}
+
+function buildHarness() {
+  const provider = new RecordingProvider();
+  const abortController = {
+    signal: {
+      aborted: false,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    },
+    abort: vi.fn(function () {
+      this.signal.aborted = true;
+    }),
+  };
+
+  const engine = {
+    lifecycleRegistry: {
+      getAbortController: vi.fn(() => abortController),
+      registerRequest: vi.fn(() => abortController),
+      unregisterRequest: vi.fn(),
+    },
+    createIntelligentBatches: vi.fn((segments) => [[segments[0]], [segments[1]]]),
+    isCancelled: vi.fn(() => false),
+  };
+
+  // Keep real implementations; only count and force a deterministic leaf result.
+  const swapSpy = vi.spyOn(LanguageSwappingService, 'applyLanguageSwapping');
+  const detectSpy = vi.spyOn(LanguageDetectionService, 'detect').mockResolvedValue('en');
+  const translateSpy = vi.spyOn(provider, 'translate');
+
+  return {
+    provider,
+    handler: new OptimizedJsonHandler(),
+    engine,
+    swapSpy,
+    detectSpy,
+    translateSpy,
+  };
+}
+
+function runOperation({ provider, handler, engine }) {
+  return handler.execute(
+    engine,
+    {
+      text: JSON.stringify(['hello world one', 'hello world two']),
+      sourceLanguage: 'auto',
+      targetLanguage: 'fa',
+      mode: TranslationMode.Select_Element,
+      messageId: 'msg-integration',
+      sessionId: 'sess-integration',
+      options: {},
+    },
+    provider,
+    'auto',
+    'fa',
+    'msg-integration',
+    {},
+  );
+}
+
+describe('OptimizedJsonHandler → ProviderCoordinator integration', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    resolveOperationSourceLanguage.mockResolvedValue({
+      canBypassSequentialGate: false,
+      bypassReason: 'HEURISTIC_RESULT',
+    });
+    getBilingualTranslationEnabledAsync.mockResolvedValue(false);
+    getBilingualTranslationModesAsync.mockResolvedValue({});
+  });
+
+  it('runs LanguageSwappingService and its detection only on batch 1 when bilingual is enabled', async () => {
+    // Bilingual ON with the Select Element mode active: LanguageSwappingService
+    // performs its internal detection on batch 1 (detected 'en' != target 'fa',
+    // so no swap occurs and ProviderCoordinator's auto-detect fallback runs
+    // too). The flag then suppresses BOTH swap entry and detection on batch 2.
+    getBilingualTranslationEnabledAsync.mockResolvedValue(true);
+    getBilingualTranslationModesAsync.mockResolvedValue({ [SELECT_ELEMENT_MODE]: true });
+
+    const { provider, handler, engine, swapSpy, detectSpy, translateSpy } = buildHarness();
+    const result = await runOperation({ provider, handler, engine });
+
+    expect(result.success).toBe(true);
+
+    // Batch 1 entered the provider unresolved (AUTO); batch 2 inherited the
+    // pair resolved by batch 1's response lifecycle.
+    expect(translateSpy).toHaveBeenCalledTimes(2);
+    expect(translateSpy.mock.calls[0].slice(1, 3)).toEqual(['auto', 'fa']);
+    expect(translateSpy.mock.calls[0][3].languagePairResolved).toBeUndefined();
+    expect(translateSpy.mock.calls[1].slice(1, 3)).toEqual(['en', 'fa']);
+    expect(translateSpy.mock.calls[1][3].languagePairResolved).toBe(true);
+
+    // LanguageSwappingService ran on batch 1 only. Pre-fix, batch 2 would
+    // re-enter it (swapSpy === 2).
+    expect(swapSpy).toHaveBeenCalledTimes(1);
+
+    // Batch 1 performs two detection entries with bilingual enabled: the swap's
+    // internal detect plus ProviderCoordinator's auto-detect fallback (source
+    // is still 'auto' after a no-swap). Both belong to batch 1 — the flag
+    // removed batch 2's repetition entirely. Pre-fix total is 4.
+    expect(detectSpy).toHaveBeenCalledTimes(2);
+    expect(detectSpy.mock.invocationCallOrder.every((order) => order < translateSpy.mock.invocationCallOrder[1])).toBe(true);
+
+    // Both provider executions ultimately received the resolved source/target.
+    expect(provider.batchCalls).toHaveLength(2);
+    provider.batchCalls.forEach(([source, target]) => {
+      expect(source).toBe('en');
+      expect(target).toBe('fa');
+    });
+  });
+
+  it('runs one swap entry and one detect entry on batch 1 when bilingual is disabled', async () => {
+    // Bilingual OFF: swap entry still runs on batch 1 but early-returns without
+    // internal detection; ProviderCoordinator performs the single auto-detect
+    // fallback. Covers the swap-only suppression contract.
+    getBilingualTranslationEnabledAsync.mockResolvedValue(false);
+    getBilingualTranslationModesAsync.mockResolvedValue({});
+
+    const { provider, handler, engine, swapSpy, detectSpy, translateSpy } = buildHarness();
+    const result = await runOperation({ provider, handler, engine });
+
+    expect(result.success).toBe(true);
+
+    expect(translateSpy).toHaveBeenCalledTimes(2);
+    expect(translateSpy.mock.calls[0].slice(1, 3)).toEqual(['auto', 'fa']);
+    expect(translateSpy.mock.calls[0][3].languagePairResolved).toBeUndefined();
+    expect(translateSpy.mock.calls[1].slice(1, 3)).toEqual(['en', 'fa']);
+    expect(translateSpy.mock.calls[1][3].languagePairResolved).toBe(true);
+
+    expect(swapSpy).toHaveBeenCalledTimes(1);
+    expect(detectSpy).toHaveBeenCalledTimes(1);
+
+    expect(provider.batchCalls).toHaveLength(2);
+    provider.batchCalls.forEach(([source, target]) => {
+      expect(source).toBe('en');
+      expect(target).toBe('fa');
+    });
+  });
+});

--- a/src/features/translation/core/managers/OptimizedJsonHandler.js
+++ b/src/features/translation/core/managers/OptimizedJsonHandler.js
@@ -170,6 +170,13 @@ export class OptimizedJsonHandler {
       logger.debug(`[JsonHandler] Executing ${batches.length} batches for ${segments.length} segments (Concurrency: ${providerConfig.rateLimit.maxConcurrent})`);
       logger.debug(`[JsonHandler] Structured batch ${laneLabel} (${mode})`);
 
+      // Tracks whether the operation's semantic source/target pair is settled.
+      // Starts as the bypass decision, and is upgraded once the first resolved
+      // batch proves a concrete source (AUTO denied path). Later batches and
+      // parent recovery inherit this fact so ProviderCoordinator does not
+      // re-run semantic swap/detection per batch.
+      let languagePairResolved = bypassAutoSequentialGate;
+
       const self = this;
       let completedBatchCount = 0;
       const batchResults = Array.from({ length: batches.length }, () => []);
@@ -365,7 +372,7 @@ export class OptimizedJsonHandler {
               parallelExecution,
               recoveryContext,
               TranslationCallPurpose.PARENT_RECOVERY,
-              bypassAutoSequentialGate
+              languagePairResolved
             );
             const translated = response?.translatedText !== undefined ? response.translatedText : response;
             const sourceText = fragment.map(({ text }) => text).join('');
@@ -944,7 +951,7 @@ export class OptimizedJsonHandler {
                parallelExecution,
                 batchExecutionContext,
                 null,
-                bypassAutoSequentialGate
+                languagePairResolved
             );
 
           // Guard provider promise so late rejection after timeout cannot become
@@ -976,6 +983,15 @@ export class OptimizedJsonHandler {
           if (!bypassAutoSequentialGate && detectedSourceLanguage === 'auto' && translatedBatchResponse?.detectedLanguage) {
             detectedSourceLanguage = translatedBatchResponse.detectedLanguage;
             logger.debug(`[JsonHandler] Captured detected source language: ${detectedSourceLanguage}`);
+
+            // The response lifecycle proved a concrete semantic source. Later
+            // batches and PARENT_RECOVERY inherit the resolved pair so the
+            // semantic swap/detection is not repeated for this operation.
+            // A response that keeps source unresolved (e.g. 'auto') does not
+            // upgrade the flag: per-batch AUTO behavior is preserved.
+            if (detectedSourceLanguage !== 'auto') {
+              languagePairResolved = true;
+            }
           }
 
           const translatedBatch = (translatedBatchResponse && typeof translatedBatchResponse === 'object' && translatedBatchResponse.translatedText !== undefined)

--- a/src/features/translation/core/managers/OptimizedJsonHandler.test.js
+++ b/src/features/translation/core/managers/OptimizedJsonHandler.test.js
@@ -626,6 +626,78 @@ describe('OptimizedJsonHandler', () => {
       expect(appendTranslationDiagnostic).toHaveBeenCalledWith(null, expect.objectContaining({ type: 'PARENT_RECOVERY_SUCCEEDED', parentId: 'g1' }));
     });
 
+    it('makes PARENT_RECOVERY inherit the pair resolved by the first AUTO batch', async () => {
+      const m2 = '@@TI_SEG_e_s_n2@@';
+      const m3 = '@@TI_SEG_e_s_n3@@';
+      const source = `A${m2}B ${m3}C`;
+      const fragment0 = { t: `A${m2}B`, i: 'n1', blockId: 'g1', isV3Fragment: true, parentId: 'g1', fragmentIndex: 0, fragmentCount: 2, fragmentJoinerBefore: '' };
+      const fragment1 = { t: `${m3}C`, i: 'n1', blockId: 'g1', isV3Fragment: true, parentId: 'g1', fragmentIndex: 1, fragmentCount: 2, fragmentJoinerBefore: ' ' };
+      mockEngine.createIntelligentBatches = vi.fn(() => [[fragment0], [fragment1]]);
+      mockProvider.translate
+        .mockResolvedValueOnce({ translatedText: [`A${m2}B`], detectedLanguage: 'en' })
+        .mockResolvedValueOnce({ translatedText: [`${m3}${m3}C`] })
+        .mockResolvedValueOnce({ translatedText: [
+          { id: 'parent-1-0', i: 'parent-1-0', text: 'A' },
+          { id: 'parent-1-1', i: 'parent-1-1', text: 'B' },
+          { id: 'parent-1-2', i: 'parent-1-2', text: 'C' },
+        ] });
+
+      const result = await handler.execute(
+        mockEngine,
+        { ...mockData, text: JSON.stringify([{ t: source, blockId: 'g1', i: 'n1' }]) },
+        mockProvider, 'auto', 'fa', 'msg-v3-auto-recovery', mockSender
+      );
+
+      expect(result.success).toBe(true);
+      expect(mockProvider.translate).toHaveBeenCalledTimes(3);
+
+      // First batch runs unresolved; it proves 'en' via detectedLanguage.
+      expect(mockProvider.translate.mock.calls[0].slice(1, 3)).toEqual(['auto', 'fa']);
+      expect(mockProvider.translate.mock.calls[0][3].languagePairResolved).toBeUndefined();
+
+      // Second batch inherits the resolved pair.
+      expect(mockProvider.translate.mock.calls[1].slice(1, 3)).toEqual(['en', 'fa']);
+      expect(mockProvider.translate.mock.calls[1][3].languagePairResolved).toBe(true);
+
+      // PARENT_RECOVERY inherits the parent batch's resolved pair and skips
+      // semantic swap/detection, without re-running the bypass decision.
+      const recoveryCall = mockProvider.translate.mock.calls[2];
+      expect(recoveryCall[3].callPurpose).toBe(TranslationCallPurpose.PARENT_RECOVERY);
+      expect(recoveryCall.slice(1, 3)).toEqual(['en', 'fa']);
+      expect(recoveryCall[3].languagePairResolved).toBe(true);
+    });
+
+    it('keeps PARENT_RECOVERY unresolved when the operation source never resolves', async () => {
+      const m2 = '@@TI_SEG_e_s_n2@@';
+      const m3 = '@@TI_SEG_e_s_n3@@';
+      const source = `A${m2}B ${m3}C`;
+      const fragment0 = { t: `A${m2}B`, i: 'n1', blockId: 'g1', isV3Fragment: true, parentId: 'g1', fragmentIndex: 0, fragmentCount: 2, fragmentJoinerBefore: '' };
+      const fragment1 = { t: `${m3}C`, i: 'n1', blockId: 'g1', isV3Fragment: true, parentId: 'g1', fragmentIndex: 1, fragmentCount: 2, fragmentJoinerBefore: ' ' };
+      mockEngine.createIntelligentBatches = vi.fn(() => [[fragment0], [fragment1]]);
+      mockProvider.translate
+        .mockResolvedValueOnce({ translatedText: [`A${m2}B`], detectedLanguage: 'auto' })
+        .mockResolvedValueOnce({ translatedText: [`${m3}${m3}C`] })
+        .mockResolvedValueOnce({ translatedText: [
+          { id: 'parent-1-0', i: 'parent-1-0', text: 'A' },
+          { id: 'parent-1-1', i: 'parent-1-1', text: 'B' },
+          { id: 'parent-1-2', i: 'parent-1-2', text: 'C' },
+        ] });
+
+      const result = await handler.execute(
+        mockEngine,
+        { ...mockData, text: JSON.stringify([{ t: source, blockId: 'g1', i: 'n1' }]) },
+        mockProvider, 'auto', 'fa', 'msg-v3-auto-unresolved-recovery', mockSender
+      );
+
+      expect(result.success).toBe(true);
+      const recoveryCall = mockProvider.translate.mock.calls.find(
+        (call) => call[3].callPurpose === TranslationCallPurpose.PARENT_RECOVERY
+      );
+      expect(recoveryCall).toBeDefined();
+      expect(recoveryCall.slice(1, 3)).toEqual(['auto', 'fa']);
+      expect(recoveryCall[3].languagePairResolved).toBeUndefined();
+    });
+
     it('emits bounded provider, mapped, reassembled, and empty-interval diagnostics', async () => {
       const m2 = '@@TI_SEG_e_s_n2@@';
       const m3 = '@@TI_SEG_e_s_n3@@';
@@ -1508,9 +1580,57 @@ describe('OptimizedJsonHandler', () => {
       const execution = handler.execute(mockEngine, mockData, mockProvider, 'auto', 'fa', `msg-auto-${bypassReason}`, mockSender);
 
       await vi.waitFor(() => expect(mockProvider.translate).toHaveBeenCalledTimes(1));
+      expect(mockProvider.translate.mock.calls[0].slice(1, 3)).toEqual(['auto', 'fa']);
       expect(mockProvider.translate.mock.calls[0][3].languagePairResolved).toBeUndefined();
       firstBatch.resolve({ translatedText: ['t1'], detectedLanguage: 'en' });
       await vi.waitFor(() => expect(mockProvider.translate).toHaveBeenCalledTimes(2));
+
+      // Batch 1 resolved the semantic pair; later batches inherit the resolved
+      // source/target and skip ProviderCoordinator swap/detection.
+      expect(mockProvider.translate.mock.calls[1].slice(1, 3)).toEqual(['en', 'fa']);
+      expect(mockProvider.translate.mock.calls[1][3].languagePairResolved).toBe(true);
+      secondBatch.resolve({ translatedText: ['t2'] });
+      await execution;
+    });
+
+    it('keeps later batches unresolved when the first batch cannot confirm a source', async () => {
+      const firstBatch = createDeferred();
+      const secondBatch = createDeferred();
+      resolveOperationSourceLanguage.mockResolvedValueOnce({
+        canBypassSequentialGate: false,
+        bypassReason: 'HEURISTIC_RESULT',
+      });
+      mockProvider.translate
+        .mockImplementationOnce(() => firstBatch.promise)
+        .mockImplementationOnce(() => secondBatch.promise);
+
+      const execution = handler.execute(mockEngine, mockData, mockProvider, 'auto', 'fa', 'msg-auto-still-unresolved', mockSender);
+
+      await vi.waitFor(() => expect(mockProvider.translate).toHaveBeenCalledTimes(1));
+      // Response keeps source unresolved ('auto'): no concrete resolution was
+      // proven, so later batches must retain per-batch AUTO behavior.
+      firstBatch.resolve({ translatedText: ['t1'], detectedLanguage: 'auto' });
+      await vi.waitFor(() => expect(mockProvider.translate).toHaveBeenCalledTimes(2));
+      expect(mockProvider.translate.mock.calls[1].slice(1, 3)).toEqual(['auto', 'fa']);
+      expect(mockProvider.translate.mock.calls[1][3].languagePairResolved).toBeUndefined();
+      secondBatch.resolve({ translatedText: ['t2'] });
+      await execution;
+    });
+
+    it('keeps later batches unresolved when the first batch returns no detection', async () => {
+      const firstBatch = createDeferred();
+      const secondBatch = createDeferred();
+      mockProvider.translate
+        .mockImplementationOnce(() => firstBatch.promise)
+        .mockImplementationOnce(() => secondBatch.promise);
+
+      const execution = handler.execute(mockEngine, mockData, mockProvider, 'auto', 'fa', 'msg-auto-no-detection', mockSender);
+
+      await vi.waitFor(() => expect(mockProvider.translate).toHaveBeenCalledTimes(1));
+      firstBatch.resolve({ translatedText: ['t1'] });
+      await vi.waitFor(() => expect(mockProvider.translate).toHaveBeenCalledTimes(2));
+      expect(mockProvider.translate.mock.calls[1].slice(1, 3)).toEqual(['auto', 'fa']);
+      expect(mockProvider.translate.mock.calls[1][3].languagePairResolved).toBeUndefined();
       secondBatch.resolve({ translatedText: ['t2'] });
       await execution;
     });


### PR DESCRIPTION
## Summary

Remove redundant AUTO language detection and swapping after semantic source/target pair has already been resolved.

## Changes

* Propagate resolved language pair to later Select Element/PDF batches.
* Reuse resolved pair during `PARENT_RECOVERY`.
* Mark resolved Whole Page session waiters with `languagePairResolved`.
* Preserve unresolved AUTO and mixed-language fallback behavior.
* Preserve Page owner and Subtitle per-batch AUTO behavior.
* Fix stale `OperationSourceLanguageResolver` comment.
* Add seam-level regression coverage through real `ProviderCoordinator` and `LanguageSwappingService` flow.

## Validation

* Targeted tests: 224 passed.
* Translation + element-selection regression: 1,920 passed.
* ESLint clean.
* `git diff --check` clean.
