### PR TITLE
fix: preserve valid results during structured parent recovery

### DIFF
--- a/src/features/translation/core/managers/OptimizedJsonHandler.js
+++ b/src/features/translation/core/managers/OptimizedJsonHandler.js
@@ -630,9 +630,61 @@ export class OptimizedJsonHandler {
           return item.uid ?? item.cellId ?? item.i ?? item.id ?? item.blockId;
         };
 
-        const collectCompleteFragments = (mappedResults) => {
-          const completeResults = [];
-          const sameBatchIds = new Set();
+        // Single publication path for the canonical batch result: dedupe against
+        // already-emitted identities, terminal acceptance, batchResults, streaming.
+        // Shared by the success path and the outer catch (preserved prefix/suffix
+        // on recovery failure) so both go through exactly-once visibility.
+        const publishResults = async (resultsToPublish, batchContext, batchIndex) => {
+          const filteredResults = [];
+          const acceptedManifestUnits = [];
+          for (let idx = 0; idx < resultsToPublish.length; idx++) {
+            const item = resultsToPublish[idx];
+            const logicalId = logicalIdOverrides.get(item) ?? extractLogicalId(item);
+            if (logicalId !== undefined && emittedLogicalIds.has(logicalId)) {
+              appendTranslationDiagnostic(executionContext, {
+                type: 'DUPLICATE_IDENTITY_SUPPRESSED',
+                stage: 'optimized-json-handler',
+                parentId: String(logicalId),
+              });
+              continue;
+            }
+            if (logicalId !== undefined) emittedLogicalIds.add(logicalId);
+            filteredResults.push(item);
+            // Track accepted manifest units for terminal observation
+            // (only valid for non-fragment batches where manifestView.units aligns positionally)
+            if (batchContext?.manifestView?.units && idx < batchContext.manifestView.units.length) {
+              acceptedManifestUnits.push(batchContext.manifestView.units[idx]);
+            }
+          }
+          // Terminal observation: accept only manifest units that survived suppression
+          if (mode === TranslationMode.Select_Element
+              && providerInstance.constructor.isAI
+              && acceptedManifestUnits.length > 0) {
+            executionContext?.onTerminalUnitsAccepted?.(acceptedManifestUnits);
+          }
+          batchResults[batchIndex] = filteredResults;
+          completedBatchCount++;
+          if (!skipStreaming && filteredResults.length > 0) {
+            await self._streamResults(
+              tabId,
+              messageId,
+              filteredResults,
+              batchIndex,
+              batches.length,
+              targetLanguage,
+              detectedSourceLanguage,
+              mode,
+              completedBatchCount,
+              abortController,
+              engine
+            );
+          }
+        };
+
+        const collectCompleteFragments = (mappedResults, state = {}) => {
+          const completeResults = state.completeResults ?? [];
+          const sameBatchIds = state.sameBatchIds ?? new Set();
+          const startIndex = state.startIndex ?? 0;
 
           const validateAndAdd = (item, logicalIdOverride) => {
             const logicalId = logicalIdOverride ?? extractLogicalId(item);
@@ -647,7 +699,8 @@ export class OptimizedJsonHandler {
             completeResults.push(item);
           };
 
-          for (const result of mappedResults) {
+          for (let index = startIndex; index < mappedResults.length; index++) {
+            const result = mappedResults[index];
            if (result?.isV2Unit === true && result?.isSplitFragment === true) {
              const { parentId, fragmentIndex, fragmentCount } = result;
              if (!parentId || !Number.isInteger(fragmentIndex) || !Number.isInteger(fragmentCount) || fragmentIndex < 0 || fragmentIndex >= fragmentCount) {
@@ -738,10 +791,12 @@ export class OptimizedJsonHandler {
                    actualMarkerCount: violation.actualMarkerCount ?? null,
                    reason,
                  });
-                   const parentError = createParentValidationError(parentIdStr, sourceText, translatedText, validation);
-                   parentError.parentRecovery.completeResults = completeResults;
-                   parentError.parentRecovery.primaryFragmentCount = orderedFragments.length;
-                   throw parentError;
+const parentError = createParentValidationError(parentIdStr, sourceText, translatedText, validation);
+                    parentError.parentRecovery.completeResults = completeResults;
+                    parentError.parentRecovery.primaryFragmentCount = orderedFragments.length;
+                    parentError.parentRecovery.sameBatchIds = sameBatchIds;
+                    parentError.parentRecovery.resumeIndex = index;
+                    throw parentError;
               }
                validateAndAdd(buildV3ParentResult(orderedFragments[0], translatedText), `v3:${parentId}`);
               parent.emitted = true;
@@ -826,6 +881,7 @@ export class OptimizedJsonHandler {
         let timeoutError = null;
         let didTimeout = false;
         let batchPayload = [];
+        let batchExecutionContext;
 
         const checkCancellation = () => {
           if (engine.isCancelled(messageId) || abortController.signal.aborted) {
@@ -930,7 +986,7 @@ export class OptimizedJsonHandler {
              ...options?.contextMetadata,
              ...(useParentConversationLifecycle && { useParentConversationLifecycle: true }),
            };
-          const batchExecutionContext = hasManifestMembership
+          batchExecutionContext = hasManifestMembership
             ? self._createBatchExecutionContext(operationExecutionContext, batch)
             : operationExecutionContext;
           const providerPromise = self._performBatchCall(
@@ -1004,6 +1060,7 @@ export class OptimizedJsonHandler {
              completeResults = collectCompleteFragments(mappedResults);
            } catch (batchError) {
              if (!batchError.parentRecovery) throw batchError;
+             const parentRecovery = batchError.parentRecovery;
              let recoveredParent;
              try {
                recoveredParent = await recoverFailedV3Parent(batchError, batchExecutionContext, parallelExecution);
@@ -1012,56 +1069,35 @@ export class OptimizedJsonHandler {
                  didTimeout = true;
                  timeoutError = recoveryError;
                }
+               // Recovery failures must still publish the results collected before
+               // the offending parent. Re-anchor the snapshot captured at the throw
+               // site when the provider rewrote the error object.
+               if (!recoveryError.parentRecovery) recoveryError.parentRecovery = parentRecovery;
                throw recoveryError;
              }
-              completeResults = [...(batchError.parentRecovery.completeResults || []), recoveredParent];
-              logicalIdOverrides.set(recoveredParent, `v3:${batchError.parentRecovery.parentId}`);
+             const { completeResults: preservedResults, sameBatchIds, resumeIndex, parentId } = parentRecovery;
+             // The recovered parent replaces the failed original; clear its fragment
+             // state so any trailing fragments are not double-collected.
+             const failedParent = fragmentedUnits.get(parentId);
+             if (failedParent) {
+               failedParent.emitted = true;
+               failedParent.fragments.clear();
+             }
+             completeResults = [...(preservedResults || []), recoveredParent];
+             logicalIdOverrides.set(recoveredParent, `v3:${parentId}`);
+             if (resumeIndex !== undefined && sameBatchIds) {
+               sameBatchIds.add(`v3:${parentId}`);
+               // Resume collection after the recovered parent so valid same-batch
+               // suffixes (Case B) survive without a full re-run.
+               completeResults = collectCompleteFragments(mappedResults, {
+                 completeResults,
+                 sameBatchIds,
+                 startIndex: resumeIndex + 1,
+               });
+             }
            }
           checkCancellation();
-          const filteredResults = [];
-          const acceptedManifestUnits = [];
-          for (let idx = 0; idx < completeResults.length; idx++) {
-            const item = completeResults[idx];
-             const logicalId = logicalIdOverrides.get(item) ?? extractLogicalId(item);
-            if (logicalId !== undefined && emittedLogicalIds.has(logicalId)) {
-              appendTranslationDiagnostic(executionContext, {
-                type: 'DUPLICATE_IDENTITY_SUPPRESSED',
-                stage: 'optimized-json-handler',
-                parentId: String(logicalId),
-              });
-              continue;
-            }
-            if (logicalId !== undefined) emittedLogicalIds.add(logicalId);
-            filteredResults.push(item);
-            // Track accepted manifest units for terminal observation
-            // (only valid for non-fragment batches where manifestView.units aligns positionally)
-            if (batchExecutionContext?.manifestView?.units && idx < batchExecutionContext.manifestView.units.length) {
-              acceptedManifestUnits.push(batchExecutionContext.manifestView.units[idx]);
-            }
-          }
-          // Terminal observation: accept only manifest units that survived suppression
-          if (mode === TranslationMode.Select_Element
-              && providerInstance.constructor.isAI
-              && acceptedManifestUnits.length > 0) {
-            executionContext?.onTerminalUnitsAccepted?.(acceptedManifestUnits);
-          }
-           batchResults[i] = filteredResults;
-          completedBatchCount++;
-          if (!skipStreaming && filteredResults.length > 0) {
-            await self._streamResults(
-              tabId,
-              messageId,
-              filteredResults,
-              i,
-              batches.length,
-              targetLanguage,
-              detectedSourceLanguage,
-              mode,
-              completedBatchCount,
-              abortController,
-              engine
-            );
-          }
+          await publishResults(completeResults, batchExecutionContext, i);
           
           const statsAfter = statsManager.getSessionSummary(sessionId);
           if (statsAfter) {
@@ -1118,13 +1154,20 @@ export class OptimizedJsonHandler {
              code: batchError.type || matchErrorToType(batchError),
              fallback: true,
            });
-           hasErrors = true;
+hasErrors = true;
            lastError = batchError;
-           batchResults[i] = [];
-          
-          // Count the attempted batch to keep progress accounting stable.
-          // Never stream the original batch as translated output on failure.
-          completedBatchCount++;
+           const preservedResults = batchError?.parentRecovery?.completeResults;
+           if (preservedResults && preservedResults.length > 0) {
+             // Recovery failed (or a later parent violated after a recovery): keep
+             // the valid prefix/suffix collected before the failing parent instead
+             // of discarding the whole batch. publishResults already counts the batch.
+             await publishResults(preservedResults, batchExecutionContext, i);
+           } else {
+             batchResults[i] = [];
+             // Count the attempted batch to keep progress accounting stable.
+             // Never stream the original batch as translated output on failure.
+             completedBatchCount++;
+           }
           
           // Stop all other batches if error is fatal (429, etc.)
           if (isFatalError(batchError)) {

--- a/src/features/translation/core/managers/OptimizedJsonHandler.test.js
+++ b/src/features/translation/core/managers/OptimizedJsonHandler.test.js
@@ -860,6 +860,307 @@ describe('OptimizedJsonHandler', () => {
       expect(mockProvider.translate.mock.calls.filter(call => call[3].callPurpose === TranslationCallPurpose.PARENT_RECOVERY)).toHaveLength(1);
     });
 
+    it('preserves a valid same-batch prefix when parent recovery fails (Case A)', async () => {
+      const browser = (await import('webextension-polyfill')).default;
+      browser.tabs.sendMessage.mockClear();
+      const m2 = '@@TI_SEG_e_s_n2@@';
+      const m3 = '@@TI_SEG_e_s_n3@@';
+      const fragment0 = { t: `X${m2}Y`, i: 'n1', blockId: 'b1', isV3Fragment: true, parentId: 'b1', fragmentIndex: 0, fragmentCount: 2, fragmentJoinerBefore: '' };
+      const fragment1 = { t: `${m3}Z`, i: 'n1', blockId: 'b1', isV3Fragment: true, parentId: 'b1', fragmentIndex: 1, fragmentCount: 2, fragmentJoinerBefore: ' ' };
+      const manifest = createRequestUnitManifest(['Hello', `X${m2}Y ${m3}Z`]);
+      const onTerminalUnitsAccepted = vi.fn();
+      const executionContext = {
+        manifestView: createManifestView(manifest),
+        onTerminalUnitsAccepted,
+      };
+      mockEngine.createIntelligentBatches = vi.fn(() => [[
+        { t: 'Hello', i: 'a', blockId: 'a' },
+        fragment0,
+        fragment1,
+      ]]);
+      mockProvider.translate
+        .mockResolvedValueOnce({ translatedText: ['Hello', `X${m2}Y`, `${m3}${m3}Z`] })
+        .mockResolvedValueOnce({ translatedText: [
+          { i: 'parent-1-0', text: 'X' },
+          { i: 'parent-1-1', text: 'Y' },
+          { i: 'parent-1-2', text: `Z${m3}` },
+        ] })
+        .mockResolvedValueOnce({ translatedText: [
+          { i: 'parent-2-0', text: 'X' },
+          { i: 'parent-2-1', text: 'Y' },
+          { i: 'parent-2-2', text: `Z${m3}` },
+        ] });
+
+      const result = await handler.execute(
+        mockEngine,
+        { ...mockData, sourceLanguage: 'en', text: JSON.stringify([
+          { t: 'Hello', i: 'a', blockId: 'a' },
+          { t: `X${m2}Y ${m3}Z`, i: 'n1', blockId: 'b1' },
+        ]) },
+        mockProvider, 'en', 'fa', 'msg-case-a-prefix-preserved', mockSender, 'unknown', executionContext
+      );
+
+      expect(result.success).toBe(false);
+      expect(result.error.type).toBe(ErrorTypes.VALIDATION);
+      expect(mockProvider.translate.mock.calls.filter(call => call[3].callPurpose === TranslationCallPurpose.PARENT_RECOVERY)).toHaveLength(2);
+      expect(result.results).toHaveLength(1);
+      expect(result.results[0]).toMatchObject({ i: 'a', t: 'Hello' });
+      // Canonical positional manifest acceptance: only the surviving prefix A
+      // reaches terminal observation, exactly once; the failed parent B never does.
+      expect(onTerminalUnitsAccepted).toHaveBeenCalledTimes(1);
+      expect(onTerminalUnitsAccepted.mock.calls[0][0]).toEqual([manifest.units[0]]);
+      const updates = browser.tabs.sendMessage.mock.calls
+        .map(([, m]) => m)
+        .filter(m => m.action === MessageActions.TRANSLATION_STREAM_UPDATE);
+      expect(updates).toHaveLength(1);
+      expect(updates[0].data.data).toHaveLength(1);
+      expect(updates[0].data.data[0].i).toBe('a');
+    });
+
+    it('preserves a valid same-batch suffix after successful parent recovery (Case B)', async () => {
+      const browser = (await import('webextension-polyfill')).default;
+      browser.tabs.sendMessage.mockClear();
+      const m2 = '@@TI_SEG_e_s_n2@@';
+      const m3 = '@@TI_SEG_e_s_n3@@';
+      const fragment0 = { t: `X${m2}Y`, i: 'n1', blockId: 'b1', isV3Fragment: true, parentId: 'b1', fragmentIndex: 0, fragmentCount: 2, fragmentJoinerBefore: '' };
+      const fragment1 = { t: `${m3}Z`, i: 'n1', blockId: 'b1', isV3Fragment: true, parentId: 'b1', fragmentIndex: 1, fragmentCount: 2, fragmentJoinerBefore: ' ' };
+      const manifest = createRequestUnitManifest(['Hello', `X${m2}Y ${m3}Z`, 'Goodbye']);
+      const onTerminalUnitsAccepted = vi.fn();
+      const executionContext = {
+        manifestView: createManifestView(manifest),
+        onTerminalUnitsAccepted,
+      };
+      mockEngine.createIntelligentBatches = vi.fn(() => [[
+        { t: 'Hello', i: 'a', blockId: 'a' },
+        fragment0,
+        fragment1,
+        { t: 'Goodbye', i: 'c', blockId: 'c' },
+      ]]);
+      mockProvider.translate
+        .mockResolvedValueOnce({ translatedText: ['Hello', `X${m2}Y`, `${m3}${m3}Z`, 'Goodbye'] })
+        .mockResolvedValueOnce({ translatedText: [
+          { i: 'parent-1-0', text: 'X' },
+          { i: 'parent-1-1', text: 'Y' },
+          { i: 'parent-1-2', text: 'Z' },
+        ] });
+
+      const result = await handler.execute(
+        mockEngine,
+        { ...mockData, sourceLanguage: 'en', text: JSON.stringify([
+          { t: 'Hello', i: 'a', blockId: 'a' },
+          { t: `X${m2}Y ${m3}Z`, i: 'n1', blockId: 'b1' },
+          { t: 'Goodbye', i: 'c', blockId: 'c' },
+        ]) },
+        mockProvider, 'en', 'fa', 'msg-case-b-suffix-preserved', mockSender, 'unknown', executionContext
+      );
+
+      expect(result.success).toBe(true);
+      expect(mockProvider.translate.mock.calls.filter(call => call[3].callPurpose === TranslationCallPurpose.PARENT_RECOVERY)).toHaveLength(1);
+      expect(result.results.map(r => r.i)).toEqual(['a', 'n1', 'c']);
+      expect(result.results[1].t).toBe(`X${m2}Y ${m3}Z`);
+      // Canonical positional manifest acceptance: A, the recovered B, and C each
+      // reach terminal observation exactly once, with no duplicate acceptance.
+      expect(onTerminalUnitsAccepted).toHaveBeenCalledTimes(1);
+      const acceptedUnits = onTerminalUnitsAccepted.mock.calls[0][0];
+      expect(acceptedUnits).toEqual([manifest.units[0], manifest.units[1], manifest.units[2]]);
+      expect(new Set(acceptedUnits).size).toBe(acceptedUnits.length);
+      const updates = browser.tabs.sendMessage.mock.calls
+        .map(([, m]) => m)
+        .filter(m => m.action === MessageActions.TRANSLATION_STREAM_UPDATE);
+      expect(updates).toHaveLength(1);
+      expect(updates[0].data.data.map(d => d.i)).toEqual(['a', 'n1', 'c']);
+    });
+
+    it('does not re-recover when a later parent violates after a successful recovery', async () => {
+      const browser = (await import('webextension-polyfill')).default;
+      browser.tabs.sendMessage.mockClear();
+      const m2 = '@@TI_SEG_e_s_n2@@';
+      const m3 = '@@TI_SEG_e_s_n3@@';
+      const b0 = { t: `X${m2}Y`, i: 'n1', blockId: 'b1', isV3Fragment: true, parentId: 'b1', fragmentIndex: 0, fragmentCount: 2, fragmentJoinerBefore: '' };
+      const b1 = { t: `${m3}Z`, i: 'n1', blockId: 'b1', isV3Fragment: true, parentId: 'b1', fragmentIndex: 1, fragmentCount: 2, fragmentJoinerBefore: ' ' };
+      const d0 = { t: `P${m2}Q`, i: 'n2', blockId: 'd1', isV3Fragment: true, parentId: 'd1', fragmentIndex: 0, fragmentCount: 2, fragmentJoinerBefore: '' };
+      const d1 = { t: `${m3}R`, i: 'n2', blockId: 'd1', isV3Fragment: true, parentId: 'd1', fragmentIndex: 1, fragmentCount: 2, fragmentJoinerBefore: ' ' };
+      mockEngine.createIntelligentBatches = vi.fn(() => [[
+        { t: 'Hello', i: 'a', blockId: 'a' },
+        b0,
+        b1,
+        { t: 'Goodbye', i: 'c', blockId: 'c' },
+        d0,
+        d1,
+      ]]);
+      mockProvider.translate
+        .mockResolvedValueOnce({ translatedText: ['Hello', `X${m2}Y`, `${m3}${m3}Z`, 'Goodbye', `P${m2}Q`, `${m3}${m3}R`] })
+        .mockResolvedValueOnce({ translatedText: [
+          { i: 'parent-1-0', text: 'X' },
+          { i: 'parent-1-1', text: 'Y' },
+          { i: 'parent-1-2', text: 'Z' },
+        ] });
+
+      const result = await handler.execute(
+        mockEngine,
+        { ...mockData, sourceLanguage: 'en', text: JSON.stringify([
+          { t: 'Hello', i: 'a', blockId: 'a' },
+          { t: `X${m2}Y ${m3}Z`, i: 'n1', blockId: 'b1' },
+          { t: 'Goodbye', i: 'c', blockId: 'c' },
+          { t: `P${m2}Q ${m3}R`, i: 'n2', blockId: 'd1' },
+        ]) },
+        mockProvider, 'en', 'fa', 'msg-multiple-invalid', mockSender
+      );
+
+      expect(result.success).toBe(false);
+      expect(mockProvider.translate.mock.calls.filter(call => call[3].callPurpose === TranslationCallPurpose.PARENT_RECOVERY)).toHaveLength(1);
+      expect(result.results).toHaveLength(3);
+      expect(result.results.map(r => r.i)).toEqual(['a', 'n1', 'c']);
+      const updates = browser.tabs.sendMessage.mock.calls
+        .map(([, m]) => m)
+        .filter(m => m.action === MessageActions.TRANSLATION_STREAM_UPDATE);
+      expect(updates).toHaveLength(1);
+      expect(updates[0].data.data.map(d => d.i)).toEqual(['a', 'n1', 'c']);
+    });
+
+    it('preserves the prefix in results without streaming when skipStreaming is set (PDF)', async () => {
+      const browser = (await import('webextension-polyfill')).default;
+      browser.tabs.sendMessage.mockClear();
+      const m2 = '@@TI_SEG_e_s_n2@@';
+      const m3 = '@@TI_SEG_e_s_n3@@';
+      const fragment0 = { t: `X${m2}Y`, i: 'n1', blockId: 'b1', isV3Fragment: true, parentId: 'b1', fragmentIndex: 0, fragmentCount: 2, fragmentJoinerBefore: '' };
+      const fragment1 = { t: `${m3}Z`, i: 'n1', blockId: 'b1', isV3Fragment: true, parentId: 'b1', fragmentIndex: 1, fragmentCount: 2, fragmentJoinerBefore: ' ' };
+      const manifest = createRequestUnitManifest(['Hello', `X${m2}Y ${m3}Z`]);
+      const onTerminalUnitsAccepted = vi.fn();
+      const executionContext = {
+        manifestView: createManifestView(manifest),
+        onTerminalUnitsAccepted,
+      };
+      mockEngine.createIntelligentBatches = vi.fn(() => [[
+        { t: 'Hello', i: 'a', blockId: 'a' },
+        fragment0,
+        fragment1,
+      ]]);
+      mockProvider.translate
+        .mockResolvedValueOnce({ translatedText: ['Hello', `X${m2}Y`, `${m3}${m3}Z`] })
+        .mockResolvedValueOnce({ translatedText: [
+          { i: 'parent-1-0', text: 'X' },
+          { i: 'parent-1-1', text: 'Y' },
+          { i: 'parent-1-2', text: `Z${m3}` },
+        ] })
+        .mockResolvedValueOnce({ translatedText: [
+          { i: 'parent-2-0', text: 'X' },
+          { i: 'parent-2-1', text: 'Y' },
+          { i: 'parent-2-2', text: `Z${m3}` },
+        ] });
+
+      const result = await handler.execute(
+        mockEngine,
+        { ...mockData, mode: 'pdf-translation', sourceLanguage: 'en', text: JSON.stringify([
+          { t: 'Hello', i: 'a', blockId: 'a' },
+          { t: `X${m2}Y ${m3}Z`, i: 'n1', blockId: 'b1' },
+        ]) },
+        mockProvider, 'en', 'fa', 'msg-skipstream-prefix', mockSender, 'unknown', executionContext
+      );
+
+      expect(result.success).toBe(false);
+      expect(result.error.type).toBe(ErrorTypes.VALIDATION);
+      expect(result.error.message).toContain('MARKER_COUNT_MISMATCH');
+      expect(result.results).toHaveLength(1);
+      expect(result.results[0]).toMatchObject({ i: 'a', t: 'Hello' });
+      expect(mockProvider.translate.mock.calls.filter(call => call[3].callPurpose === TranslationCallPurpose.PARENT_RECOVERY)).toHaveLength(2);
+      const updates = browser.tabs.sendMessage.mock.calls
+        .map(([, m]) => m)
+        .filter(m => m.action === MessageActions.TRANSLATION_STREAM_UPDATE);
+      expect(updates).toHaveLength(0);
+      // Canonical terminal observation is mode-gated: structured PDF never reaches
+      // onTerminalUnitsAccepted (existing PDF exclusion), so preservation must not
+      // introduce acceptance where the contract forbids it.
+      expect(onTerminalUnitsAccepted).not.toHaveBeenCalled();
+    });
+
+    it('recovers a parent with an empty prefix snapshot and keeps the suffix', async () => {
+      const browser = (await import('webextension-polyfill')).default;
+      browser.tabs.sendMessage.mockClear();
+      const m2 = '@@TI_SEG_e_s_n2@@';
+      const m3 = '@@TI_SEG_e_s_n3@@';
+      const fragment0 = { t: `X${m2}Y`, i: 'n1', blockId: 'b1', isV3Fragment: true, parentId: 'b1', fragmentIndex: 0, fragmentCount: 2, fragmentJoinerBefore: '' };
+      const fragment1 = { t: `${m3}Z`, i: 'n1', blockId: 'b1', isV3Fragment: true, parentId: 'b1', fragmentIndex: 1, fragmentCount: 2, fragmentJoinerBefore: ' ' };
+      mockEngine.createIntelligentBatches = vi.fn(() => [[
+        fragment0,
+        fragment1,
+        { t: 'Goodbye', i: 'c', blockId: 'c' },
+      ]]);
+      mockProvider.translate
+        .mockResolvedValueOnce({ translatedText: [`X${m2}Y`, `${m3}${m3}Z`, 'Goodbye'] })
+        .mockResolvedValueOnce({ translatedText: [
+          { i: 'parent-1-0', text: 'X' },
+          { i: 'parent-1-1', text: 'Y' },
+          { i: 'parent-1-2', text: 'Z' },
+        ] });
+
+      const result = await handler.execute(
+        mockEngine,
+        { ...mockData, sourceLanguage: 'en', text: JSON.stringify([
+          { t: `X${m2}Y ${m3}Z`, i: 'n1', blockId: 'b1' },
+          { t: 'Goodbye', i: 'c', blockId: 'c' },
+        ]) },
+        mockProvider, 'en', 'fa', 'msg-no-prefix-resume', mockSender
+      );
+
+      expect(result.success).toBe(true);
+      expect(mockProvider.translate.mock.calls.filter(call => call[3].callPurpose === TranslationCallPurpose.PARENT_RECOVERY)).toHaveLength(1);
+      expect(result.results.map(r => r.i)).toEqual(['n1', 'c']);
+      expect(result.results[0].t).toBe(`X${m2}Y ${m3}Z`);
+      const updates = browser.tabs.sendMessage.mock.calls
+        .map(([, m]) => m)
+        .filter(m => m.action === MessageActions.TRANSLATION_STREAM_UPDATE);
+      expect(updates).toHaveLength(1);
+      expect(updates[0].data.data.map(d => d.i)).toEqual(['n1', 'c']);
+    });
+
+    it('does not leak recovered parent fragment state into later batches', async () => {
+      const browser = (await import('webextension-polyfill')).default;
+      browser.tabs.sendMessage.mockClear();
+      const m2 = '@@TI_SEG_e_s_n2@@';
+      const m3 = '@@TI_SEG_e_s_n3@@';
+      const b0 = { t: `X${m2}Y`, i: 'n1', blockId: 'b1', isV3Fragment: true, parentId: 'b1', fragmentIndex: 0, fragmentCount: 2, fragmentJoinerBefore: '' };
+      const b1 = { t: `${m3}Z`, i: 'n1', blockId: 'b1', isV3Fragment: true, parentId: 'b1', fragmentIndex: 1, fragmentCount: 2, fragmentJoinerBefore: ' ' };
+      const d0 = { t: `P${m2}Q`, i: 'n2', blockId: 'd1', isV3Fragment: true, parentId: 'd1', fragmentIndex: 0, fragmentCount: 2, fragmentJoinerBefore: '' };
+      const d1 = { t: `${m3}R`, i: 'n2', blockId: 'd1', isV3Fragment: true, parentId: 'd1', fragmentIndex: 1, fragmentCount: 2, fragmentJoinerBefore: ' ' };
+      mockEngine.createIntelligentBatches = vi.fn(() => [[b0, b1], [d0, d1]]);
+      mockProvider.translate.mockImplementation((texts, _source, _target, options) => {
+        if (options.callPurpose === TranslationCallPurpose.PARENT_RECOVERY) {
+          return Promise.resolve({ translatedText: [
+            { i: 'parent-1-0', text: 'X' },
+            { i: 'parent-1-1', text: 'Y' },
+            { i: 'parent-1-2', text: 'Z' },
+          ] });
+        }
+        const first = Array.isArray(texts) ? (texts[0]?.t ?? texts[0]) : '';
+        if (String(first).startsWith('P')) {
+          return Promise.resolve({ translatedText: [`P${m2}Q`, `${m3}R`] });
+        }
+        return Promise.resolve({ translatedText: [`X${m2}Y`, `${m3}${m3}Z`] });
+      });
+
+      const result = await handler.execute(
+        mockEngine,
+        { ...mockData, sourceLanguage: 'en', text: JSON.stringify([
+          { t: `X${m2}Y ${m3}Z`, i: 'n1', blockId: 'b1' },
+          { t: `P${m2}Q ${m3}R`, i: 'n2', blockId: 'd1' },
+        ]) },
+        mockProvider, 'en', 'fa', 'msg-fragment-cleanup', mockSender
+      );
+
+      expect(result.success).toBe(true);
+      expect(mockProvider.translate.mock.calls.filter(call => call[3].callPurpose === TranslationCallPurpose.PARENT_RECOVERY)).toHaveLength(1);
+      expect(result.results.map(r => r.i)).toEqual(['n1', 'n2']);
+      expect(result.results[0].t).toBe(`X${m2}Y ${m3}Z`);
+      expect(result.results[1].t).toBe(`P${m2}Q ${m3}R`);
+      const updates = browser.tabs.sendMessage.mock.calls
+        .map(([, m]) => m)
+        .filter(m => m.action === MessageActions.TRANSLATION_STREAM_UPDATE);
+      expect(updates).toHaveLength(2);
+      const streamedIds = updates.flatMap(u => u.data.data.map(d => d.i)).sort();
+      expect(streamedIds).toEqual(['n1', 'n2']);
+    });
+
     it('does not start parent recovery when its inherited deadline is expired', async () => {
       const m2 = '@@TI_SEG_e_s_n2@@';
       const m3 = '@@TI_SEG_e_s_n3@@';


### PR DESCRIPTION
## Summary

Harden structured parent recovery so valid same-batch translation results are not lost when another parent requires recovery.

## Changes

- Preserve validated same-batch results when parent recovery fails.
- Resume collection after successful parent recovery so trailing valid parents are not silently dropped.
- Route preserved results through canonical publication flow:
  - deduplication
  - terminal acceptance
  - batch results
  - streaming
- Preserve source order after recovery.
- Clean recovered fragment state before continuing collection.
- Keep single parent recovery per batch behavior unchanged.

## Recovery / Accounting Audit Results

Additional recovery/accounting items were audited:

- R3 health/circuit-breaker propagation: no fix required.
- R4 timeout ownership: no fix required.
- R5 whole-batch outer retry: current atomic retry policy preferred; no change.
- R1 telemetry/purpose accounting: deferred to dedicated purpose-attributed stats audit.

## Validation

- `OptimizedJsonHandler` tests: passed.
- Translation regression suite: passed.
- Select Element / acceptance regression coverage: passed.
- ESLint: clean.
- `git diff --check`: clean.

## Out of Scope

- Multiple parent recoveries within one batch.
- Queue retry redesign.
- Partial recovery state across outer attempts.
- Telemetry/purpose accounting changes.
- Health/circuit-breaker changes.
- Timeout ownership changes.