### PR TITLE
fix: route translation streams to originating frame

### DIFF
--- a/src/features/translation/core/StreamingManager.js
+++ b/src/features/translation/core/StreamingManager.js
@@ -112,6 +112,24 @@ export class StreamingManager extends ResourceTracker {
   }
 
   /**
+   * Build tabs.sendMessage arguments with frame targeting when the originating
+   * frame identity is available. Keeps the legacy broadcast call (2 args) when
+   * frameId is absent so extension-page and non-tab flows are unchanged.
+   * @param {number} tabId - Target tab ID
+   * @param {object} message - Message payload
+   * @param {object|null} senderInfo - Stored sender details
+   * @returns {Array} - sendMessage arguments
+   * @private
+   */
+  _createTabSendArgs(tabId, message, senderInfo) {
+    const args = [tabId, message];
+    if (typeof senderInfo?.frameId === 'number') {
+      args.push({ frameId: senderInfo.frameId });
+    }
+    return args;
+  }
+
+  /**
    * Stream batch results to content script
    * @param {string} messageId - Message ID
    * @param {string[]} batchResults - Results for this batch
@@ -164,7 +182,7 @@ export class StreamingManager extends ResourceTracker {
 
       // Send to content script or internal extension page (popup, sidepanel, options)
       if (senderInfo.tab?.id) {
-        await browser.tabs.sendMessage(senderInfo.tab.id, streamMessage);
+        await browser.tabs.sendMessage(...this._createTabSendArgs(senderInfo.tab.id, streamMessage, senderInfo));
       } else {
         // Broadcast to internal extension pages
         await browser.runtime.sendMessage(streamMessage);
@@ -219,7 +237,7 @@ export class StreamingManager extends ResourceTracker {
 
       // Send to content script or internal extension page
       if (senderInfo.tab?.id) {
-        await browser.tabs.sendMessage(senderInfo.tab.id, streamErrorMessage);
+        await browser.tabs.sendMessage(...this._createTabSendArgs(senderInfo.tab.id, streamErrorMessage, senderInfo));
         logger.debug(`[StreamingManager] Streamed error for batch ${batchIndex} to tab ${senderInfo.tab.id}`);
       } else {
         await browser.runtime.sendMessage(streamErrorMessage);
@@ -283,7 +301,7 @@ export class StreamingManager extends ResourceTracker {
       );
 
       if (senderInfo && senderInfo.tab?.id) {
-        await browser.tabs.sendMessage(senderInfo.tab.id, streamEndMessage);
+        await browser.tabs.sendMessage(...this._createTabSendArgs(senderInfo.tab.id, streamEndMessage, senderInfo));
         
         // Log Session Summary for streaming
         statsManager.printSummary(streamInfo.sessionId, { 

--- a/src/features/translation/core/StreamingManager.test.js
+++ b/src/features/translation/core/StreamingManager.test.js
@@ -176,6 +176,19 @@ describe('StreamingManager', () => {
       
       expect(browser.tabs.sendMessage).not.toHaveBeenCalled();
     });
+
+    it('should target the originating iframe when sender has frameId', async () => {
+      const { default: browser } = await import('webextension-polyfill');
+      const messageId = 'msg-frame';
+      streamingManager.initializeStream(messageId, { tab: { id: 999 }, frameId: 3 }, { providerName: 'P' }, ['s1']);
+
+      await streamingManager.streamBatchResults(messageId, ['res'], ['s1'], 0);
+
+      expect(browser.tabs.sendMessage).toHaveBeenCalledWith(999, expect.objectContaining({
+        action: MessageActions.TRANSLATION_STREAM_UPDATE,
+        messageId: messageId
+      }), { frameId: 3 });
+    });
   });
 
   describe('streamBatchError', () => {
@@ -201,6 +214,19 @@ describe('StreamingManager', () => {
           })
         })
       }));
+    });
+
+    it('should target the originating iframe on error', async () => {
+      const { default: browser } = await import('webextension-polyfill');
+      const messageId = 'msg-frame-err';
+      streamingManager.initializeStream(messageId, { tab: { id: 123 }, frameId: 3 }, { providerName: 'P' }, ['s1']);
+
+      await streamingManager.streamBatchError(messageId, new Error('boom'), 0);
+
+      expect(browser.tabs.sendMessage).toHaveBeenCalledWith(123, expect.objectContaining({
+        action: MessageActions.TRANSLATION_STREAM_UPDATE,
+        data: expect.objectContaining({ success: false })
+      }), { frameId: 3 });
     });
   });
 
@@ -244,6 +270,19 @@ describe('StreamingManager', () => {
       
       await streamingManager.completeStream(messageId, true);
       expect(streamingManager.stats).toEqual(statsAfterFirst);
+    });
+
+    it('should target the top frame with frameId 0', async () => {
+      const { default: browser } = await import('webextension-polyfill');
+      const messageId = 'msg-topframe';
+      streamingManager.initializeStream(messageId, { tab: { id: 123 }, frameId: 0 }, { providerName: 'P' }, ['s1']);
+
+      await streamingManager.completeStream(messageId, true);
+
+      expect(browser.tabs.sendMessage).toHaveBeenCalledWith(123, expect.objectContaining({
+        action: MessageActions.TRANSLATION_STREAM_END,
+        data: expect.objectContaining({ success: true })
+      }), { frameId: 0 });
     });
   });
 
@@ -306,6 +345,19 @@ describe('StreamingManager', () => {
           }
         })
       }));
+    });
+
+    it('keeps timeout completion targeted at the originating frame', async () => {
+      const { default: browser } = await import('webextension-polyfill');
+      const messageId = 'msg-timeout-frame';
+      streamingManager.initializeStream(messageId, { tab: { id: 1 }, frameId: 3 }, { providerName: 'P' }, ['s1']);
+
+      await streamingManager.cancelStream(messageId, 'Translation timed out', true, 'PROGRESS_TIMEOUT');
+
+      expect(browser.tabs.sendMessage).toHaveBeenCalledWith(1, expect.objectContaining({
+        action: MessageActions.TRANSLATION_STREAM_END,
+        data: expect.objectContaining({ timedOut: true })
+      }), { frameId: 3 });
     });
 
     it('should mark stream as cancelled and complete it', async () => {

--- a/src/features/translation/core/managers/OptimizedJsonHandler.js
+++ b/src/features/translation/core/managers/OptimizedJsonHandler.js
@@ -81,6 +81,7 @@ export class OptimizedJsonHandler {
     };
     const sessionId = data.sessionId || messageId;
     const tabId = sender?.tab?.id;
+    const frameId = typeof sender?.frameId === 'number' ? sender.frameId : null;
     const abortController = engine.lifecycleRegistry.getAbortController(messageId) || 
                              engine.lifecycleRegistry.registerRequest(messageId, typeof text === 'string' ? text.substring(0, 100) : '', uiContext);
 
@@ -676,7 +677,8 @@ export class OptimizedJsonHandler {
               mode,
               completedBatchCount,
               abortController,
-              engine
+              engine,
+              frameId
             );
           }
         };
@@ -1202,9 +1204,9 @@ hasErrors = true;
 
       if (!skipStreaming) {
         if (hasErrors) {
-          await this._sendStreamError(tabId, messageId, lastError, targetLanguage, detectedSourceLanguage, mode);
+          await this._sendStreamError(tabId, messageId, lastError, targetLanguage, detectedSourceLanguage, mode, frameId);
         } else {
-          await this._sendStreamEnd(tabId, messageId, providerInstance.providerName, targetLanguage, detectedSourceLanguage, mode);
+          await this._sendStreamEnd(tabId, messageId, providerInstance.providerName, targetLanguage, detectedSourceLanguage, mode, frameId);
         }
       }
 
@@ -1400,7 +1402,7 @@ hasErrors = true;
     });
   }
 
-  async _streamResults(tabId, messageId, translatedData, batchIndex, totalBatches, targetLanguage, sourceLanguage, translationMode, completedCount = null, abortController = null, engine = null) {
+  async _streamResults(tabId, messageId, translatedData, batchIndex, totalBatches, targetLanguage, sourceLanguage, translationMode, completedCount = null, abortController = null, engine = null, frameId = null) {
     if (!tabId) return;
     const isCancelled = () => {
       if (abortController?.signal?.aborted) return true;
@@ -1431,13 +1433,15 @@ hasErrors = true;
     try {
       await Promise.resolve();
       if (isCancelled()) return;
-      await browser.tabs.sendMessage(tabId, streamMessage);
+      const sendArgs = [tabId, streamMessage];
+      if (typeof frameId === 'number') sendArgs.push({ frameId });
+      await browser.tabs.sendMessage(...sendArgs);
     } catch (err) {
       logger.warn(`[JsonHandler] Failed to stream to tab ${tabId}:`, err.message);
     }
   }
 
-  async _sendStreamEnd(tabId, messageId, providerName, targetLanguage, sourceLanguage, translationMode) {
+  async _sendStreamEnd(tabId, messageId, providerName, targetLanguage, sourceLanguage, translationMode, frameId = null) {
     if (!tabId) return;
     const endMessage = {
       action: MessageActions.TRANSLATION_STREAM_END,
@@ -1453,11 +1457,13 @@ hasErrors = true;
       }
     };
     try {
-      await browser.tabs.sendMessage(tabId, endMessage);
+      const sendArgs = [tabId, endMessage];
+      if (typeof frameId === 'number') sendArgs.push({ frameId });
+      await browser.tabs.sendMessage(...sendArgs);
     } catch { /* ignore */ }
   }
 
-  async _sendStreamError(tabId, messageId, lastError, targetLanguage, sourceLanguage, translationMode) {
+  async _sendStreamError(tabId, messageId, lastError, targetLanguage, sourceLanguage, translationMode, frameId = null) {
     if (!tabId) return;
     const endMessage = {
       action: MessageActions.TRANSLATION_STREAM_END,
@@ -1476,7 +1482,9 @@ hasErrors = true;
       }
     };
     try {
-      await browser.tabs.sendMessage(tabId, endMessage);
+      const sendArgs = [tabId, endMessage];
+      if (typeof frameId === 'number') sendArgs.push({ frameId });
+      await browser.tabs.sendMessage(...sendArgs);
     } catch { /* ignore */ }
   }
 }

--- a/src/features/translation/core/managers/OptimizedJsonHandler.test.js
+++ b/src/features/translation/core/managers/OptimizedJsonHandler.test.js
@@ -4124,4 +4124,95 @@ describe('OptimizedJsonHandler', () => {
       });
     });
   });
+
+  describe('frame-targeted streaming routing', () => {
+    const mockData = {
+      text: JSON.stringify([{ i: 'n1', t: 'Hello.' }]),
+      sourceLanguage: 'en',
+      targetLanguage: 'fa',
+      mode: 'select_element',
+      messageId: 'msg-1',
+      sessionId: 'sess-1'
+    };
+
+    it('targets the originating iframe for update and end sends', async () => {
+      const browser = (await import('webextension-polyfill')).default;
+      browser.tabs.sendMessage.mockClear();
+
+      mockEngine.createIntelligentBatches = vi.fn(() => [[{ i: 'n1', t: 'Hello.' }]]);
+      mockProvider.translate.mockResolvedValueOnce({ translatedText: ['Bonjour.'] });
+
+      const result = await handler.execute(
+        mockEngine,
+        mockData,
+        mockProvider, 'en', 'fa', 'msg-frame-3', { tab: { id: 123 }, frameId: 3 }
+      );
+
+      expect(result.success).toBe(true);
+      const calls = browser.tabs.sendMessage.mock.calls;
+      const update = calls.find(([, m]) => m.action === MessageActions.TRANSLATION_STREAM_UPDATE);
+      const end = calls.find(([, m]) => m.action === MessageActions.TRANSLATION_STREAM_END);
+      expect(update).toEqual([123, expect.objectContaining({ action: MessageActions.TRANSLATION_STREAM_UPDATE }), { frameId: 3 }]);
+      expect(end).toEqual([123, expect.objectContaining({ action: MessageActions.TRANSLATION_STREAM_END }), { frameId: 3 }]);
+    });
+
+    it('targets the originating iframe for error sends', async () => {
+      const browser = (await import('webextension-polyfill')).default;
+      browser.tabs.sendMessage.mockClear();
+
+      mockEngine.createIntelligentBatches = vi.fn(() => [[{ i: 'n1', t: 'Hello.' }]]);
+      const error = new Error('provider down');
+      error.type = 'NETWORK_ERROR';
+      mockProvider.translate.mockRejectedValueOnce(error);
+
+      const result = await handler.execute(
+        mockEngine,
+        mockData,
+        mockProvider, 'en', 'fa', 'msg-frame-err', { tab: { id: 123 }, frameId: 3 }
+      );
+
+      expect(result.success).toBe(false);
+      const calls = browser.tabs.sendMessage.mock.calls;
+      const end = calls.find(([, m]) => m.action === MessageActions.TRANSLATION_STREAM_END);
+      expect(end).toEqual([123, expect.objectContaining({ action: MessageActions.TRANSLATION_STREAM_END }), { frameId: 3 }]);
+    });
+
+    it('targets the top frame explicitly with frameId 0', async () => {
+      const browser = (await import('webextension-polyfill')).default;
+      browser.tabs.sendMessage.mockClear();
+
+      mockEngine.createIntelligentBatches = vi.fn(() => [[{ i: 'n1', t: 'Hello.' }]]);
+      mockProvider.translate.mockResolvedValueOnce({ translatedText: ['Bonjour.'] });
+
+      const result = await handler.execute(
+        mockEngine,
+        mockData,
+        mockProvider, 'en', 'fa', 'msg-frame-0', { tab: { id: 123 }, frameId: 0 }
+      );
+
+      expect(result.success).toBe(true);
+      const calls = browser.tabs.sendMessage.mock.calls;
+      expect(calls.length).toBeGreaterThan(0);
+      expect(calls.every(([, , options]) => options && options.frameId === 0)).toBe(true);
+    });
+
+    it('keeps broadcast behavior when frameId is unavailable', async () => {
+      const browser = (await import('webextension-polyfill')).default;
+      browser.tabs.sendMessage.mockClear();
+
+      mockEngine.createIntelligentBatches = vi.fn(() => [[{ i: 'n1', t: 'Hello.' }]]);
+      mockProvider.translate.mockResolvedValueOnce({ translatedText: ['Bonjour.'] });
+
+      const result = await handler.execute(
+        mockEngine,
+        mockData,
+        mockProvider, 'en', 'fa', 'msg-no-frame', { tab: { id: 123 } }
+      );
+
+      expect(result.success).toBe(true);
+      const calls = browser.tabs.sendMessage.mock.calls;
+      expect(calls.length).toBeGreaterThan(0);
+      calls.forEach((call) => expect(call).toHaveLength(2));
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Fix translation streaming inside iframes by routing stream messages only to the frame that originated the request.

Previously, `tabs.sendMessage(tabId, message)` broadcast translation stream messages to every frame in the tab. Message IDs prevented most application-level cross-talk, but unrelated frames still received the traffic.

## Changes

- Route `StreamingManager` messages using `{ frameId }` when frame identity is available:
  - batch updates
  - batch errors
  - stream completion
  - timeout/cancellation completion
- Route `OptimizedJsonHandler` stream messages to the originating frame:
  - translation updates
  - stream end
  - stream error
- Explicitly support top-frame `frameId: 0`.
- Preserve existing 2-argument `tabs.sendMessage` behavior when `frameId` is unavailable.
- Keep message payloads, ACK routing, buffering, and lifecycle semantics unchanged.

## Validation

- StreamingManager + OptimizedJsonHandler: 181 tests passed.
- Integration/streaming regressions: 68 tests passed.
- Select Element regressions: 235 tests passed.
- ESLint clean.
- `git diff --check` clean.

## Out of Scope

- Stream buffer TTL/cleanup changes.
- ACK identity changes.
- Message ID changes.
- Conversation acceptance changes.
- Streaming payload/schema changes.