### PR TITLE
test: harden translation timeout and abort lifecycle coverage

### DIFF
--- a/src/features/translation/core/managers/OptimizedJsonHandler.integration.test.js
+++ b/src/features/translation/core/managers/OptimizedJsonHandler.integration.test.js
@@ -9,10 +9,27 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 // provider.translate and ProviderCoordinator.execute are NOT mocked, so the
 // swap/detect guard under test runs through its real control flow.
 
+vi.mock('webextension-polyfill', () => ({
+  default: {
+    runtime: { getBrowserInfo: vi.fn(), getManifest: () => ({ version: '1.0.0' }) },
+    storage: { local: { get: vi.fn(), set: vi.fn() } },
+    tabs: { sendMessage: vi.fn() },
+  },
+}));
+
+vi.mock('@/shared/proxy/ProxyManager.js', () => ({
+  proxyManager: {
+    fetch: vi.fn(),
+    setConfig: vi.fn(),
+    testConnection: vi.fn(),
+  },
+}));
+
 vi.mock('@/shared/logging/logger.js', () => ({
   getScopedLogger: () => ({
     init: vi.fn(),
     debug: vi.fn(),
+    debugLazy: vi.fn(),
     info: vi.fn(),
     warn: vi.fn(),
     error: vi.fn(),
@@ -23,6 +40,9 @@ vi.mock('@/features/translation/core/TranslationStatsManager.js', () => ({
   statsManager: {
     getSessionSummary: vi.fn(() => ({ chars: 100, originalChars: 80 })),
     printSummary: vi.fn(),
+    recordRequest: vi.fn(() => ({ globalCallId: 1, sessionCallId: 1 })),
+    recordSuccess: vi.fn(),
+    recordError: vi.fn(),
   },
 }));
 
@@ -49,6 +69,7 @@ import { OptimizedJsonHandler } from './OptimizedJsonHandler.js';
 import { BaseProvider } from '@/features/translation/providers/BaseProvider.js';
 import { LanguageSwappingService } from '@/features/translation/providers/LanguageSwappingService.js';
 import { LanguageDetectionService } from '@/shared/services/LanguageDetectionService.js';
+import { proxyManager } from '@/shared/proxy/ProxyManager.js';
 import { TranslationMode, getBilingualTranslationEnabledAsync, getBilingualTranslationModesAsync } from '@/shared/config/config.js';
 
 // 'select-element' is the real MessageContexts.SELECT_ELEMENT value that
@@ -67,6 +88,34 @@ class RecordingProvider extends BaseProvider {
   async _batchTranslate(texts, sourceLang, targetLang) {
     this.batchCalls.push([sourceLang, targetLang, texts.slice()]);
     return texts.map((text) => `[tr]${typeof text === 'object' ? (text.t ?? text.text) : text}`);
+  }
+}
+
+// Real provider reaching the fetch boundary. _batchTranslate executes through the
+// real ProviderRequestEngine (executeRequest → executeApiCall → proxyManager.fetch)
+// so a timeout's shared abort signal can be observed at the physical HTTP seam.
+class FetchSignalProvider extends BaseProvider {
+  static batchStrategy = 'json';
+  static isAI = true;
+
+  constructor() {
+    super('FetchSignalProvider');
+  }
+
+  async _batchTranslate(texts, sourceLang, targetLang, translateMode, engine, messageId, abortController, priority, sessionId, expectedFormat, options = {}) {
+    return this._executeRequest({
+      url: 'https://fetch-signal.test/translate',
+      fetchOptions: {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ texts }),
+      },
+      extractResponse: (data) => data.results || [],
+      context: 'structured-batch',
+      abortController,
+      sessionId,
+      callPurpose: options.callPurpose,
+    });
   }
 }
 
@@ -205,5 +254,80 @@ describe('OptimizedJsonHandler → ProviderCoordinator integration', () => {
       expect(source).toBe('en');
       expect(target).toBe('fa');
     });
+  });
+});
+
+describe('OptimizedJsonHandler physical abort propagation', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    proxyManager.fetch.mockReset();
+    proxyManager.setConfig.mockReset();
+    proxyManager.testConnection.mockReset();
+    resolveOperationSourceLanguage.mockResolvedValue({
+      canBypassSequentialGate: false,
+      bypassReason: 'HEURISTIC_RESULT',
+    });
+    getBilingualTranslationEnabledAsync.mockResolvedValue(false);
+    getBilingualTranslationModesAsync.mockResolvedValue({});
+  });
+
+  it('timeout aborts the physical fetch through the shared AbortController signal', async () => {
+    const provider = new FetchSignalProvider();
+    const abortController = {
+      signal: {
+        aborted: false,
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+      },
+      abort: vi.fn(function () {
+        this.signal.aborted = true;
+      }),
+    };
+
+    const engine = {
+      lifecycleRegistry: {
+        getAbortController: vi.fn(() => abortController),
+        registerRequest: vi.fn(() => abortController),
+        unregisterRequest: vi.fn(),
+      },
+      createIntelligentBatches: vi.fn((segments) => segments.map((segment) => [segment])),
+      isCancelled: vi.fn(() => false),
+    };
+    const handler = new OptimizedJsonHandler();
+
+    // Leaf network boundary hangs; the request can only terminate via the
+    // shared abort signal reaching this fetch call.
+    proxyManager.fetch.mockImplementation(() => new Promise(() => {}));
+
+    const execution = handler.execute(
+      engine,
+      {
+        text: JSON.stringify(['hello world']),
+        sourceLanguage: 'en',
+        targetLanguage: 'fa',
+        mode: TranslationMode.Select_Element,
+        messageId: 'msg-fetch-abort',
+        sessionId: 'sess-fetch-abort',
+        options: {},
+      },
+      provider,
+      'en',
+      'fa',
+      'msg-fetch-abort',
+      { tab: { id: 1 }, frameId: 0 },
+      'unknown',
+      { deadlineAt: Date.now() + 500 }
+    );
+    execution.catch(() => {});
+
+    await vi.waitFor(() => expect(proxyManager.fetch).toHaveBeenCalledTimes(1));
+    expect(proxyManager.fetch.mock.calls[0][1].signal).toBe(abortController.signal);
+    expect(abortController.signal.aborted).toBe(false);
+
+    await expect(execution).rejects.toMatchObject({ type: 'TRANSLATION_TIMEOUT' });
+
+    // The same signal object handed to fetch transitioned to aborted.
+    expect(proxyManager.fetch.mock.calls[0][1].signal.aborted).toBe(true);
+    expect(engine.lifecycleRegistry.unregisterRequest).toHaveBeenCalledWith('msg-fetch-abort');
   });
 });

--- a/src/features/translation/core/managers/OptimizedJsonHandler.test.js
+++ b/src/features/translation/core/managers/OptimizedJsonHandler.test.js
@@ -1284,6 +1284,8 @@ describe('OptimizedJsonHandler', () => {
         execution.catch(() => {});
         await vi.waitFor(() => expect(mockProvider.translate).toHaveBeenCalledTimes(2));
         expect(mockProvider.translate.mock.calls[1][3].callPurpose).toBe(TranslationCallPurpose.PARENT_RECOVERY);
+        // Recovery call shares the same abort signal/controller as the operation.
+        expect(mockProvider.translate.mock.calls[1][3].abortController).toBe(mockAbortController);
         await new Promise(resolve => setTimeout(resolve, 60));
          await expect(execution).rejects.toMatchObject({ type: ErrorTypes.TRANSLATION_TIMEOUT });
         expect(mockAbortController.abort).toHaveBeenCalledTimes(1);
@@ -1293,6 +1295,16 @@ describe('OptimizedJsonHandler', () => {
           .map(([, message]) => message)
           .filter(message => message.action === MessageActions.TRANSLATION_STREAM_UPDATE);
         expect(updates).toHaveLength(0);
+        // No late recovery terminal either.
+        expect(browser.tabs.sendMessage.mock.calls
+          .map(([, message]) => message)
+          .filter(message => message.action === MessageActions.TRANSLATION_STREAM_END)).toHaveLength(0);
+        // No second recovery stage starts after timeout; the late recovery
+        // settlement publishes nothing.
+        expect(mockProvider.translate).toHaveBeenCalledTimes(2);
+        // Owned recovery-stage abort listener removed and request unregistered.
+        expect(mockAbortController.signal.removeEventListener).toHaveBeenCalled();
+        expect(mockEngine.lifecycleRegistry.unregisterRequest).toHaveBeenCalledWith('msg-v3-recovery-timeout');
       } finally {
         recovery.resolve({ translatedText: ['late'] });
         getAIConversationHistoryEnabledAsync.mockResolvedValue(false);
@@ -4121,6 +4133,86 @@ describe('OptimizedJsonHandler', () => {
         const result = await execution;
         expect(result.success).toBe(false);
         expect(result.error.type).toBe(ErrorTypes.USER_CANCELLED);
+      });
+    });
+
+    describe('timeout/abort lifecycle hardening', () => {
+      it('emits exactly one terminal on timeout and unregisters owned resources', async () => {
+        vi.useFakeTimers();
+        const browser = (await import('webextension-polyfill')).default;
+        const { getAIConversationHistoryEnabledAsync } = await import('@/shared/config/config.js');
+        const firstBatch = createDeferred();
+        const unregister = vi.fn();
+        mockEngine.lifecycleRegistry = { ...mockEngine.lifecycleRegistry, unregisterRequest: unregister };
+
+        const timeoutDiagnostics = () => appendTranslationDiagnostic.mock.calls
+          .filter(([, diagnostic]) => diagnostic?.type === 'BATCH_TIMEOUT');
+
+        try {
+          getAIConversationHistoryEnabledAsync.mockResolvedValue(true);
+          mockProvider.translate.mockImplementationOnce(() => firstBatch.promise);
+          browser.tabs.sendMessage.mockClear();
+
+          const execution = handler.execute(mockEngine, mockData, mockProvider, 'en', 'fa', 'msg-exact-terminal', mockSender);
+          execution.catch(() => {});
+          await vi.waitFor(() => expect(mockProvider.translate).toHaveBeenCalledTimes(1));
+
+          // Real timer-driven timeout (not a manual signal.aborted flag).
+          await vi.advanceTimersByTimeAsync(TRANSLATION_BATCH_EXECUTION_TIMEOUT_MS);
+          await expect(execution).rejects.toMatchObject({ type: ErrorTypes.TRANSLATION_TIMEOUT });
+          expect(mockAbortController.abort).toHaveBeenCalledTimes(1);
+
+          // Owned per-batch abort listener removed and request unregistered.
+          expect(mockAbortController.signal.removeEventListener).toHaveBeenCalled();
+          expect(unregister).toHaveBeenCalledWith('msg-exact-terminal');
+
+          // Late provider settlement must not publish any stream/terminal message.
+          firstBatch.resolve({ translatedText: ['late'] });
+          await Promise.resolve();
+          await Promise.resolve();
+
+          const actions = browser.tabs.sendMessage.mock.calls.map(([, m]) => m?.action);
+          expect(actions).toHaveLength(0);
+          expect(actions).not.toContain(MessageActions.TRANSLATION_STREAM_UPDATE);
+          expect(actions).not.toContain(MessageActions.TRANSLATION_STREAM_END);
+
+          // No later callback fires after completion.
+          await vi.advanceTimersByTimeAsync(300000);
+          expect(mockAbortController.abort).toHaveBeenCalledTimes(1);
+          expect(timeoutDiagnostics()).toHaveLength(1);
+        } finally {
+          firstBatch.resolve({ translatedText: ['late'] });
+          getAIConversationHistoryEnabledAsync.mockResolvedValue(false);
+          vi.useRealTimers();
+        }
+      });
+
+      it('unregisters the request and removes listeners on cancellation', async () => {
+        vi.useRealTimers();
+        const { getAIConversationHistoryEnabledAsync } = await import('@/shared/config/config.js');
+        getAIConversationHistoryEnabledAsync.mockResolvedValue(false);
+
+        const unregister = vi.fn();
+        mockEngine.lifecycleRegistry = { ...mockEngine.lifecycleRegistry, unregisterRequest: unregister };
+        const firstBatch = createDeferred();
+        mockEngine.createIntelligentBatches = vi.fn(() => [[{ i: 'n1', t: 'Hello.' }]]);
+        mockProvider.translate.mockImplementationOnce(() => firstBatch.promise);
+
+        const execution = handler.execute(
+          mockEngine,
+          { ...mockData, sourceLanguage: 'en', text: JSON.stringify([{ i: 'n1', t: 'Hello.' }]) },
+          mockProvider, 'en', 'fa', 'msg-cancel-cleanup', mockSender
+        );
+
+        await vi.waitFor(() => expect(mockProvider.translate).toHaveBeenCalledTimes(1));
+        mockAbortController.signal.aborted = true;
+        firstBatch.resolve({ translatedText: ['Hello.'] });
+
+        const result = await execution;
+        expect(result.success).toBe(false);
+        expect(result.error.type).toBe(ErrorTypes.USER_CANCELLED);
+        expect(unregister).toHaveBeenCalledWith('msg-cancel-cleanup');
+        expect(mockAbortController.signal.removeEventListener).toHaveBeenCalled();
       });
     });
   });

--- a/src/features/translation/core/translation-engine.test.js
+++ b/src/features/translation/core/translation-engine.test.js
@@ -55,6 +55,7 @@ vi.mock("./managers/OptimizedJsonHandler.js", () => {
 // 3. Imports
 import { TranslationEngine } from './translation-engine.js';
 import { MessageActions } from "@/shared/messaging/core/MessageActions.js";
+import { ErrorTypes } from "@/shared/error-management/ErrorTypes.js";
 import { getEnableDictionaryAsync } from "@/shared/config/config.js";
 
 // 4. Other dependencies
@@ -126,6 +127,21 @@ describe('TranslationEngine', () => {
       'PROGRESS_TIMEOUT',
       'Streaming translation timed out'
     );
+  });
+
+  it('formatError for a timeout yields a terminal response without streaming marker', () => {
+    const timeoutError = new Error('Batch translation timed out after 300000ms');
+    timeoutError.type = ErrorTypes.TRANSLATION_TIMEOUT;
+
+    const result = engine.formatError(timeoutError, 'select-element');
+
+    expect(result.success).toBe(false);
+    expect(result.error.type).toBe(ErrorTypes.TRANSLATION_TIMEOUT);
+    expect(result.error.message).toBe('Batch translation timed out after 300000ms');
+    // The timeout response must not claim active streaming: the coordinator
+    // routes on `response.streaming` truthiness, and a timeout returns the
+    // error response directly instead of awaiting a stream that never ends.
+    expect('streaming' in result).toBe(false);
   });
 
   describe('handleMessage', () => {


### PR DESCRIPTION
## Summary

Add regression coverage for `OptimizedJsonHandler` timeout and abort lifecycle.

This PR is test-only. No production behavior changes.

## Changes

- Verify operation timeout propagates shared `AbortSignal` to physical fetch boundary.
- Verify timeout aborts active provider work.
- Verify late provider settlement cannot publish stream updates or terminal messages.
- Verify timeout produces a terminal non-streaming error response.
- Verify lifecycle request cleanup and abort-listener removal.
- Verify cancellation performs lifecycle cleanup.
- Verify `PARENT_RECOVERY` uses the same operation `AbortController`.
- Verify timeout during parent recovery prevents additional recovery stages.

## Validation

- Timeout/abort tests: passed.
- `OptimizedJsonHandler` tests: passed.
- Integration/streaming regressions: passed.
- Select Element regressions: passed.
- ESLint: clean.
- `git diff --check`: clean.

## Scope

Test hardening only.

No changes to:
- production timeout budgets
- abort/deadline ownership
- recovery semantics
- QueueManager retry behavior
- streaming protocol
- conversation lifecycle