### PR TITLE
fix: reject empty Microsoft Edge translation responses

### DIFF
--- a/src/features/translation/providers/MicrosoftEdgeProvider.js
+++ b/src/features/translation/providers/MicrosoftEdgeProvider.js
@@ -190,7 +190,17 @@ export class MicrosoftEdgeProvider extends BaseTranslateProvider {
               err.type = ErrorTypes.API_RESPONSE_INVALID;
               throw err;
             }
-            return item.translations.map(t => t.text).join(' ');
+            // No silent empty-fill: an empty, whitespace-only, or non-string
+            // joined result must fail loudly so the caller never mistakes it
+            // for a successful translation. Identity output (text === source)
+            // is legitimate and remains accepted.
+            const joinedText = item.translations.map(t => t.text).join(' ');
+            if (typeof joinedText !== 'string' || !joinedText.trim()) {
+              const err = new Error(ErrorTypes.API_RESPONSE_INVALID);
+              err.type = ErrorTypes.API_RESPONSE_INVALID;
+              throw err;
+            }
+            return joinedText;
           });
         },
         context: 'edge-translate-chunk',

--- a/src/features/translation/providers/MicrosoftEdgeProvider.test.js
+++ b/src/features/translation/providers/MicrosoftEdgeProvider.test.js
@@ -123,6 +123,33 @@ describe('MicrosoftEdgeProvider', () => {
         .rejects.toMatchObject({ type: 'API_RESPONSE_INVALID' });
     });
 
+    it.each([
+      ['empty translations array', [{ translations: [] }]],
+      ['empty translated text', [{ translations: [{ text: '' }] }]],
+      ['whitespace-only translated text', [{ translations: [{ text: '   ' }] }]],
+    ])('throws API_RESPONSE_INVALID for %s instead of returning empty output', async (_label, response) => {
+      vi.spyOn(provider, '_getAuthToken').mockResolvedValue('valid-token');
+
+      vi.spyOn(provider, '_executeRequest').mockImplementation(async (opts) => {
+        return opts.extractResponse(response);
+      });
+
+      await expect(provider._translateChunk(['Hello'], 'en', 'fa', 'selection', null))
+        .rejects.toMatchObject({ type: 'API_RESPONSE_INVALID' });
+    });
+
+    it('accepts identity translation where translated text equals source', async () => {
+      vi.spyOn(provider, '_getAuthToken').mockResolvedValue('valid-token');
+
+      const identityResponse = [{ translations: [{ text: 'URL' }] }];
+
+      vi.spyOn(provider, '_executeRequest').mockImplementation(async (opts) => {
+        return opts.extractResponse(identityResponse);
+      });
+
+      await expect(provider._translateChunk(['URL'], 'en', 'fa', 'selection', null)).resolves.toEqual(['URL']);
+    });
+
     it('should throw API_RESPONSE_INVALID when a translation item lacks translations', async () => {
       vi.spyOn(provider, '_getAuthToken').mockResolvedValue('valid-token');
 


### PR DESCRIPTION
## Summary

Harden Microsoft Edge translation response validation so empty output cannot be treated as a successful translation.

## Changes

- Reject empty `translations` arrays.
- Reject empty translated text.
- Reject whitespace-only translated text.
- Throw existing `API_RESPONSE_INVALID` error for unusable output.
- Preserve existing multi-translation joining behavior.
- Preserve valid identity translations where translated text equals source.

## Validation

- Edge + BaseTranslateProvider + BrowserAPI + Bing: 40 tests passed.
- Provider + translation core regression: 1,126 tests passed.
- ESLint: clean.
- `git diff --check`: clean.

## Scope

No changes to:

- BrowserAPI
- Bing
- BaseTranslateProvider
- UnifiedModeCoordinator
- ProviderCoordinator
- cardinality/retry semantics

## Follow-up

Separate audit remains for `UnifiedModeCoordinator` string-item under-return source fallback.