### PR TITLE
fix: honor skipped results in whole page translation

### DIFF
--- a/src/features/page-translation/PageTranslationScheduler.js
+++ b/src/features/page-translation/PageTranslationScheduler.js
@@ -448,6 +448,16 @@ export class PageTranslationScheduler extends ResourceTracker {
 
       batch.forEach((item, index) => {
         const translatedItem = translatedTexts[index];
+
+        // Explicit unresolved marker (isSkipped): keep original text and count as
+        // failed, never as translated. Only trust isSkipped === true; identity
+        // translations (text === source) are legitimate and resolve normally.
+        if (typeof translatedItem === 'object' && translatedItem !== null && translatedItem.isSkipped === true) {
+          item.resolve(typeof translatedItem.text === 'string' ? translatedItem.text : item.text);
+          this.failedCount++;
+          return;
+        }
+
         let translatedText = "";
 
         if (typeof translatedItem === 'string') {

--- a/src/features/page-translation/PageTranslationScheduler.test.js
+++ b/src/features/page-translation/PageTranslationScheduler.test.js
@@ -160,6 +160,69 @@ describe('PageTranslationScheduler', () => {
       expect(scheduler.translatedCount).toBe(1);
     });
 
+    it('should honor isSkipped items in a mixed partial result', async () => {
+      const itemA = { text: 'A', resolve: vi.fn(), score: 1 };
+      const itemB = { text: 'B', resolve: vi.fn(), score: 1 };
+      const itemC = { text: 'C', resolve: vi.fn(), score: 1 };
+      scheduler.queue.push(itemA, itemB, itemC);
+
+      PageTranslationFluidFilter.process.mockReturnValue({ batchItems: [itemA, itemB, itemC], remainingItems: [] });
+      vi.spyOn(scheduler, '_getBatchConfig').mockResolvedValue({ providerRegistryId: 'google', targetLanguage: 'fa' });
+
+      safeSendMessage.mockResolvedValue({
+        success: true,
+        translatedText: JSON.stringify(['A2', { text: 'B', isSkipped: true }, 'C2'])
+      });
+
+      await scheduler.flush();
+
+      expect(itemA.resolve).toHaveBeenCalledWith('A2');
+      expect(itemB.resolve).toHaveBeenCalledWith('B');
+      expect(itemC.resolve).toHaveBeenCalledWith('C2');
+      expect(scheduler.translatedCount).toBe(2);
+      expect(scheduler.failedCount).toBe(1);
+    });
+
+    it('should preserve originals without counting translated when all items are skipped', async () => {
+      const itemA = { text: 'A', resolve: vi.fn(), score: 1 };
+      const itemB = { text: 'B', resolve: vi.fn(), score: 1 };
+      scheduler.queue.push(itemA, itemB);
+
+      PageTranslationFluidFilter.process.mockReturnValue({ batchItems: [itemA, itemB], remainingItems: [] });
+      vi.spyOn(scheduler, '_getBatchConfig').mockResolvedValue({ providerRegistryId: 'google', targetLanguage: 'fa' });
+
+      safeSendMessage.mockResolvedValue({
+        success: true,
+        translatedText: JSON.stringify([{ text: 'A', isSkipped: true }, { text: 'B', isSkipped: true }])
+      });
+
+      await scheduler.flush();
+
+      expect(itemA.resolve).toHaveBeenCalledWith('A');
+      expect(itemB.resolve).toHaveBeenCalledWith('B');
+      expect(scheduler.translatedCount).toBe(0);
+      expect(scheduler.failedCount).toBe(2);
+    });
+
+    it('should not treat identity translations as skipped', async () => {
+      const mockItem = { text: 'URL', resolve: vi.fn(), score: 1 };
+      scheduler.queue.push(mockItem);
+
+      PageTranslationFluidFilter.process.mockReturnValue({ batchItems: [mockItem], remainingItems: [] });
+      vi.spyOn(scheduler, '_getBatchConfig').mockResolvedValue({ providerRegistryId: 'google', targetLanguage: 'fa' });
+
+      safeSendMessage.mockResolvedValue({
+        success: true,
+        translatedText: JSON.stringify(['URL'])
+      });
+
+      await scheduler.flush();
+
+      expect(mockItem.resolve).toHaveBeenCalledWith('URL');
+      expect(scheduler.translatedCount).toBe(1);
+      expect(scheduler.failedCount).toBe(0);
+    });
+
     it('should handle batch errors and fallback to original text', async () => {
       const mockItem = { text: 'Failed Text', resolve: vi.fn(), score: 1 };
       scheduler.queue.push(mockItem);


### PR DESCRIPTION
## Summary

Fix Whole Page translation handling for unresolved batch items.

When an AI/custom provider under-returned results, `UnifiedModeCoordinator` preserved the original text and marked the item with `isSkipped:true`.
Whole Page ignored that marker and counted the source-text fallback as a successful translation.

## Changes

- Honor explicit `isSkipped:true` results in `PageTranslationScheduler`.
- Preserve original text for skipped items.
- Count skipped items as failed instead of translated.
- Continue processing valid translations from the same batch.
- Preserve normal identity translations where translated text equals source.

## Validation

- Page translation targeted tests: 98 passed.
- Full page-translation suite: 108 passed.
- Translation core/coordinator regression: 585 passed.
- ESLint: clean.
- `git diff --check`: clean.

## Scope

No changes to:

- `UnifiedModeCoordinator`
- provider behavior
- Subtitle handling
- batching/retry semantics
- TranslationOutcome

## Follow-up

`UnifiedModeCoordinator` plain-string under-return fallback remains unmarked, but no current production caller uses that branch.