### PR TITLE
fix: mark under-returned string batch results as skipped

### DIFF
--- a/src/core/services/translation/UnifiedModeCoordinator.js
+++ b/src/core/services/translation/UnifiedModeCoordinator.js
@@ -498,10 +498,10 @@ export class UnifiedModeCoordinator {
           : (typeof item === 'string' ? item : item.text);
 
         if (typeof item === 'string') {
-          return { text: translatedText };
+          return { text: translatedText, ...(isMissingResult ? { isSkipped: true } : {}) };
         }
 
-        // Object results (e.g. subtitle) carry an explicit unresolved marker so
+        // Results carry an explicit unresolved marker so
         // downstream consumers never mistake the source fallback for real output.
         return { ...item, text: translatedText, ...(isMissingResult ? { isSkipped: true } : {}) };
       });

--- a/src/core/services/translation/UnifiedModeCoordinator.test.js
+++ b/src/core/services/translation/UnifiedModeCoordinator.test.js
@@ -792,6 +792,57 @@ describe('UnifiedModeCoordinator', () => {
       expect(result[0].isSkipped).toBeUndefined();
     });
 
+    it('marks missing plain-string results as skipped', async () => {
+      mockEngine.getProvider.mockResolvedValue({
+        translate: vi.fn().mockResolvedValue(['A2', 'B2'])
+      });
+
+      const result = await coordinator._processGenericBatch(
+        batchRequest(),
+        { translationEngine: mockEngine },
+        batchOptions(['A', 'B', 'C'])
+      );
+
+      expect(result).toEqual([
+        { text: 'A2' },
+        { text: 'B2' },
+        { text: 'C', isSkipped: true }
+      ]);
+    });
+
+    it('does not mark complete plain-string results as skipped', async () => {
+      mockEngine.getProvider.mockResolvedValue({
+        translate: vi.fn().mockResolvedValue(['A2', 'B2'])
+      });
+
+      const result = await coordinator._processGenericBatch(
+        batchRequest(),
+        { translationEngine: mockEngine },
+        batchOptions(['A', 'B'])
+      );
+
+      expect(result).toEqual([{ text: 'A2' }, { text: 'B2' }]);
+      result.forEach(item => expect(item.isSkipped).toBeUndefined());
+    });
+
+    it('marks missing mixed string and object results according to item shape', async () => {
+      mockEngine.getProvider.mockResolvedValue({
+        translate: vi.fn().mockResolvedValue(['A2'])
+      });
+
+      const result = await coordinator._processGenericBatch(
+        batchRequest(),
+        { translationEngine: mockEngine },
+        batchOptions(['A', { text: 'B' }, 'C'])
+      );
+
+      expect(result).toEqual([
+        { text: 'A2' },
+        { text: 'B', isSkipped: true },
+        { text: 'C', isSkipped: true }
+      ]);
+    });
+
     it('fires the generic batch guard exactly at the canonical batch execution budget', async () => {
       vi.useFakeTimers();
       try {
@@ -877,6 +928,30 @@ describe('UnifiedModeCoordinator', () => {
       result.forEach(item => expect(item.isSkipped).toBeUndefined());
       expect(result[0].text).toBe('ترجمهٔ A');
       expect(result[1].text).toBe('ترجمهٔ B');
+    });
+  });
+
+  describe('Page plain-string batch payloads', () => {
+    it('marks under-returned string-array payload items as skipped', async () => {
+      mockEngine.getProvider.mockResolvedValue({
+        translate: vi.fn().mockResolvedValue(['A2'])
+      });
+
+      const result = await coordinator.processPageTranslation({
+        mode: TranslationMode.Page,
+        messageId: 'm-page-strings',
+        data: {
+          text: JSON.stringify(['A', 'B']),
+          provider: 'google',
+          sourceLanguage: 'en',
+          targetLanguage: 'fa'
+        }
+      }, { translationEngine: mockEngine });
+
+      expect(JSON.parse(result.translatedText)).toEqual([
+        { text: 'A2' },
+        { text: 'B', isSkipped: true }
+      ]);
     });
   });
 });


### PR DESCRIPTION
## Summary

Harden generic batch result handling for plain-string items.

When a provider under-returned results, missing string items previously fell back to source text without an `isSkipped` marker. Downstream consumers could
therefore treat unresolved source text as a successful translation.

## Changes

- Mark missing plain-string results with `isSkipped: true`.
- Align string fallback semantics with existing object-item behavior.
- Preserve complete and identity translations unchanged.
- Preserve mixed string/object batch support.
- Add Page-route coverage for string-array payloads.

## Before

```
{ text: 'C' }
````

Missing result could appear successful.

## After

```
{ text: 'C', isSkipped: true }
```

Consumers can correctly identify unresolved source fallback.

## Scope

No changes to:

* provider behavior
* Page scheduler
* Subtitle validation
* message schema
* batching/retry logic
* object-item fallback semantics

## Validation

* UnifiedModeCoordinator: 41 passed
* Page translation: 108 passed
* Subtitle: 29 passed
* Translation core: 447 passed
* ESLint: clean
* `git diff --check`: clean
