### PR TITLE
fix: add bounded multi-parent recovery per batch

### DIFF
--- a/src/features/translation/core/managers/OptimizedJsonHandler.js
+++ b/src/features/translation/core/managers/OptimizedJsonHandler.js
@@ -22,6 +22,7 @@ import { findProviderById } from '@/features/translation/providers/ProviderManif
 import { resolveOperationSourceLanguage } from '@/features/translation/core/OperationSourceLanguageResolver.js';
 
 const logger = getScopedLogger(LOG_COMPONENTS.TRANSLATION, 'OptimizedJsonHandler');
+const MAX_PARENT_RECOVERIES_PER_BATCH = 2;
 
 function getParentRecoveryCharacterLimit(primaryFragmentLimit) {
   // Halve marker density without producing tiny recovery calls; never exceed primary policy.
@@ -1056,48 +1057,53 @@ const parentError = createParentValidationError(parentIdStr, sourceText, transla
             ? translatedBatchResponse.translatedText
             : translatedBatchResponse;
 
-          const mappedResults = self._mapResults(batchPayload, translatedBatch, executionContext);
-           let completeResults;
-           try {
-             completeResults = collectCompleteFragments(mappedResults);
-           } catch (batchError) {
-             if (!batchError.parentRecovery) throw batchError;
-             const parentRecovery = batchError.parentRecovery;
-             let recoveredParent;
-             try {
-               recoveredParent = await recoverFailedV3Parent(batchError, batchExecutionContext, parallelExecution);
-             } catch (recoveryError) {
-               if ((recoveryError?.type || matchErrorToType(recoveryError)) === ErrorTypes.TRANSLATION_TIMEOUT) {
-                 didTimeout = true;
-                 timeoutError = recoveryError;
-               }
-               // Recovery failures must still publish the results collected before
-               // the offending parent. Re-anchor the snapshot captured at the throw
-               // site when the provider rewrote the error object.
-               if (!recoveryError.parentRecovery) recoveryError.parentRecovery = parentRecovery;
-               throw recoveryError;
-             }
-             const { completeResults: preservedResults, sameBatchIds, resumeIndex, parentId } = parentRecovery;
-             // The recovered parent replaces the failed original; clear its fragment
-             // state so any trailing fragments are not double-collected.
-             const failedParent = fragmentedUnits.get(parentId);
-             if (failedParent) {
-               failedParent.emitted = true;
-               failedParent.fragments.clear();
-             }
-             completeResults = [...(preservedResults || []), recoveredParent];
-             logicalIdOverrides.set(recoveredParent, `v3:${parentId}`);
-             if (resumeIndex !== undefined && sameBatchIds) {
-               sameBatchIds.add(`v3:${parentId}`);
-               // Resume collection after the recovered parent so valid same-batch
-               // suffixes (Case B) survive without a full re-run.
-               completeResults = collectCompleteFragments(mappedResults, {
-                 completeResults,
-                 sameBatchIds,
-                 startIndex: resumeIndex + 1,
-               });
-             }
-           }
+           const mappedResults = self._mapResults(batchPayload, translatedBatch, executionContext);
+            let completeResults;
+            let collectionState;
+            let parentRecoveryCount = 0;
+            while (true) {
+              try {
+                completeResults = collectCompleteFragments(mappedResults, collectionState);
+                break;
+              } catch (batchError) {
+                if (!batchError.parentRecovery || parentRecoveryCount >= MAX_PARENT_RECOVERIES_PER_BATCH) throw batchError;
+                parentRecoveryCount++;
+                const parentRecovery = batchError.parentRecovery;
+                let recoveredParent;
+                try {
+                  recoveredParent = await recoverFailedV3Parent(batchError, batchExecutionContext, parallelExecution);
+                } catch (recoveryError) {
+                  if ((recoveryError?.type || matchErrorToType(recoveryError)) === ErrorTypes.TRANSLATION_TIMEOUT) {
+                    didTimeout = true;
+                    timeoutError = recoveryError;
+                  }
+                  // Recovery failures must still publish the results collected before
+                  // the offending parent. Re-anchor the snapshot captured at the throw
+                  // site when the provider rewrote the error object.
+                  if (!recoveryError.parentRecovery) recoveryError.parentRecovery = parentRecovery;
+                  throw recoveryError;
+                }
+                const { completeResults: preservedResults, sameBatchIds, resumeIndex, parentId } = parentRecovery;
+                // The recovered parent replaces the failed original; clear its fragment
+                // state so any trailing fragments are not double-collected.
+                const failedParent = fragmentedUnits.get(parentId);
+                if (failedParent) {
+                  failedParent.emitted = true;
+                  failedParent.fragments.clear();
+                }
+                completeResults = [...(preservedResults || []), recoveredParent];
+                logicalIdOverrides.set(recoveredParent, `v3:${parentId}`);
+                if (resumeIndex === undefined || !sameBatchIds) break;
+                sameBatchIds.add(`v3:${parentId}`);
+                // Resume collection after the recovered parent so valid same-batch
+                // suffixes survive without a full re-run.
+                collectionState = {
+                  completeResults,
+                  sameBatchIds,
+                  startIndex: resumeIndex + 1,
+                };
+              }
+            }
           checkCancellation();
           await publishResults(completeResults, batchExecutionContext, i);
           

--- a/src/features/translation/core/managers/OptimizedJsonHandler.test.js
+++ b/src/features/translation/core/managers/OptimizedJsonHandler.test.js
@@ -971,7 +971,7 @@ describe('OptimizedJsonHandler', () => {
       expect(updates[0].data.data.map(d => d.i)).toEqual(['a', 'n1', 'c']);
     });
 
-    it('does not re-recover when a later parent violates after a successful recovery', async () => {
+    it('recovers two invalid parents and publishes the physical batch once', async () => {
       const browser = (await import('webextension-polyfill')).default;
       browser.tabs.sendMessage.mockClear();
       const m2 = '@@TI_SEG_e_s_n2@@';
@@ -980,6 +980,12 @@ describe('OptimizedJsonHandler', () => {
       const b1 = { t: `${m3}Z`, i: 'n1', blockId: 'b1', isV3Fragment: true, parentId: 'b1', fragmentIndex: 1, fragmentCount: 2, fragmentJoinerBefore: ' ' };
       const d0 = { t: `P${m2}Q`, i: 'n2', blockId: 'd1', isV3Fragment: true, parentId: 'd1', fragmentIndex: 0, fragmentCount: 2, fragmentJoinerBefore: '' };
       const d1 = { t: `${m3}R`, i: 'n2', blockId: 'd1', isV3Fragment: true, parentId: 'd1', fragmentIndex: 1, fragmentCount: 2, fragmentJoinerBefore: ' ' };
+      const manifest = createRequestUnitManifest(['Hello', `X${m2}Y ${m3}Z`, 'Goodbye', `P${m2}Q ${m3}R`, 'End']);
+      const onTerminalUnitsAccepted = vi.fn();
+      const executionContext = {
+        manifestView: createManifestView(manifest),
+        onTerminalUnitsAccepted,
+      };
       mockEngine.createIntelligentBatches = vi.fn(() => [[
         { t: 'Hello', i: 'a', blockId: 'a' },
         b0,
@@ -987,14 +993,16 @@ describe('OptimizedJsonHandler', () => {
         { t: 'Goodbye', i: 'c', blockId: 'c' },
         d0,
         d1,
+        { t: 'End', i: 'e', blockId: 'e' },
       ]]);
       mockProvider.translate
-        .mockResolvedValueOnce({ translatedText: ['Hello', `X${m2}Y`, `${m3}${m3}Z`, 'Goodbye', `P${m2}Q`, `${m3}${m3}R`] })
-        .mockResolvedValueOnce({ translatedText: [
-          { i: 'parent-1-0', text: 'X' },
-          { i: 'parent-1-1', text: 'Y' },
-          { i: 'parent-1-2', text: 'Z' },
-        ] });
+        .mockResolvedValueOnce({ translatedText: ['Hello', `X${m2}Y`, `${m3}${m3}Z`, 'Goodbye', `P${m2}Q`, `${m3}${m3}R`, 'End'] })
+        .mockImplementation((texts, _source, _target, options) => {
+          if (options.callPurpose === TranslationCallPurpose.PARENT_RECOVERY) {
+            return Promise.resolve({ translatedText: texts.map((item) => ({ i: item.i, text: item.text })) });
+          }
+          return Promise.resolve({ translatedText: texts });
+        });
 
       const result = await handler.execute(
         mockEngine,
@@ -1004,18 +1012,156 @@ describe('OptimizedJsonHandler', () => {
           { t: 'Goodbye', i: 'c', blockId: 'c' },
           { t: `P${m2}Q ${m3}R`, i: 'n2', blockId: 'd1' },
         ]) },
-        mockProvider, 'en', 'fa', 'msg-multiple-invalid', mockSender
+        mockProvider, 'en', 'fa', 'msg-multiple-invalid', mockSender, 'unknown', executionContext
+      );
+
+      expect(result.success).toBe(true);
+      const recoveryCalls = mockProvider.translate.mock.calls.filter(call => call[3].callPurpose === TranslationCallPurpose.PARENT_RECOVERY);
+      expect(recoveryCalls).toHaveLength(2);
+      expect(recoveryCalls.map(call => call[3].executionContext.deadlineAt))
+        .toEqual([mockProvider.translate.mock.calls[0][3].executionContext.deadlineAt, mockProvider.translate.mock.calls[0][3].executionContext.deadlineAt]);
+      expect(recoveryCalls.every(call => call[3].abortController === mockAbortController)).toBe(true);
+      expect(result.results.map(r => r.i)).toEqual(['a', 'n1', 'c', 'n2', 'e']);
+      expect(new Set(result.results.map(r => r.i)).size).toBe(result.results.length);
+      expect(onTerminalUnitsAccepted).toHaveBeenCalledTimes(1);
+      expect(onTerminalUnitsAccepted.mock.calls[0][0]).toEqual(manifest.units);
+      const updates = browser.tabs.sendMessage.mock.calls
+        .map(([, m]) => m)
+        .filter(m => m.action === MessageActions.TRANSLATION_STREAM_UPDATE);
+      expect(updates).toHaveLength(1);
+      expect(updates[0].data.data.map(d => d.i)).toEqual(['a', 'n1', 'c', 'n2', 'e']);
+      const ends = browser.tabs.sendMessage.mock.calls
+        .map(([, m]) => m)
+        .filter(m => m.action === MessageActions.TRANSLATION_STREAM_END);
+      expect(ends).toHaveLength(1);
+      expect(ends[0].data.success).toBe(true);
+    });
+
+    it('preserves results when the second parent recovery fails', async () => {
+      const browser = (await import('webextension-polyfill')).default;
+      browser.tabs.sendMessage.mockClear();
+      isFatalError.mockReturnValue(false);
+      const m2 = '@@TI_SEG_e_s_n2@@';
+      const m3 = '@@TI_SEG_e_s_n3@@';
+      const b0 = { t: `X${m2}Y`, i: 'n1', blockId: 'b1', isV3Fragment: true, parentId: 'b1', fragmentIndex: 0, fragmentCount: 2, fragmentJoinerBefore: '' };
+      const b1 = { t: `${m3}Z`, i: 'n1', blockId: 'b1', isV3Fragment: true, parentId: 'b1', fragmentIndex: 1, fragmentCount: 2, fragmentJoinerBefore: ' ' };
+      const d0 = { t: `P${m2}Q`, i: 'n2', blockId: 'd1', isV3Fragment: true, parentId: 'd1', fragmentIndex: 0, fragmentCount: 2, fragmentJoinerBefore: '' };
+      const d1 = { t: `${m3}R`, i: 'n2', blockId: 'd1', isV3Fragment: true, parentId: 'd1', fragmentIndex: 1, fragmentCount: 2, fragmentJoinerBefore: ' ' };
+      const manifest = createRequestUnitManifest(['Hello', `X${m2}Y ${m3}Z`, 'Goodbye', `P${m2}Q ${m3}R`, 'End']);
+      const onTerminalUnitsAccepted = vi.fn();
+      const executionContext = {
+        manifestView: createManifestView(manifest),
+        onTerminalUnitsAccepted,
+      };
+      mockEngine.createIntelligentBatches = vi.fn(() => [[
+        { t: 'Hello', i: 'a', blockId: 'a' },
+        b0,
+        b1,
+        { t: 'Goodbye', i: 'c', blockId: 'c' },
+        d0,
+        d1,
+        { t: 'End', i: 'e', blockId: 'e' },
+      ]]);
+      let recoveryCall = 0;
+      mockProvider.translate.mockImplementation((texts, _source, _target, options) => {
+        if (options.callPurpose === TranslationCallPurpose.PARENT_RECOVERY) {
+          recoveryCall++;
+          const isValidRecovery = recoveryCall === 1;
+          return Promise.resolve({ translatedText: texts.map((item) => ({
+            i: item.i,
+            text: isValidRecovery ? item.text : `${item.text}${m2}`,
+          })) });
+        }
+        return Promise.resolve({ translatedText: ['Hello', `X${m2}Y`, `${m3}${m3}Z`, 'Goodbye', `P${m2}Q`, `${m3}${m3}R`, 'End'] });
+      });
+
+      const result = await handler.execute(
+        mockEngine,
+        { ...mockData, sourceLanguage: 'en', text: JSON.stringify([
+          { t: 'Hello', i: 'a', blockId: 'a' },
+          { t: `X${m2}Y ${m3}Z`, i: 'n1', blockId: 'b1' },
+          { t: 'Goodbye', i: 'c', blockId: 'c' },
+          { t: `P${m2}Q ${m3}R`, i: 'n2', blockId: 'd1' },
+          { t: 'End', i: 'e', blockId: 'e' },
+        ]) },
+        mockProvider, 'en', 'fa', 'msg-second-recovery-fail', mockSender, 'unknown', executionContext
       );
 
       expect(result.success).toBe(false);
-      expect(mockProvider.translate.mock.calls.filter(call => call[3].callPurpose === TranslationCallPurpose.PARENT_RECOVERY)).toHaveLength(1);
-      expect(result.results).toHaveLength(3);
+      expect(result.error.type).toBe(ErrorTypes.VALIDATION);
+      expect(result.error.message).toContain('fragmented parent d1');
       expect(result.results.map(r => r.i)).toEqual(['a', 'n1', 'c']);
+      expect(result.results).not.toEqual(expect.arrayContaining([{ i: 'n2' }, { i: 'e' }]));
+      expect(mockProvider.translate.mock.calls.filter(call => call[3].callPurpose === TranslationCallPurpose.PARENT_RECOVERY)).toHaveLength(3);
+      expect(onTerminalUnitsAccepted).toHaveBeenCalledTimes(1);
+      expect(onTerminalUnitsAccepted.mock.calls[0][0]).toEqual(manifest.units.slice(0, 3));
       const updates = browser.tabs.sendMessage.mock.calls
         .map(([, m]) => m)
         .filter(m => m.action === MessageActions.TRANSLATION_STREAM_UPDATE);
       expect(updates).toHaveLength(1);
       expect(updates[0].data.data.map(d => d.i)).toEqual(['a', 'n1', 'c']);
+      const ends = browser.tabs.sendMessage.mock.calls
+        .map(([, m]) => m)
+        .filter(m => m.action === MessageActions.TRANSLATION_STREAM_END);
+      expect(ends).toHaveLength(1);
+      expect(ends[0].data.success).toBe(false);
+    });
+
+    it('stops after two parent recovery lifecycles and preserves the accumulated prefix', async () => {
+      const browser = (await import('webextension-polyfill')).default;
+      browser.tabs.sendMessage.mockClear();
+      const m2 = '@@TI_SEG_e_s_n2@@';
+      const m3 = '@@TI_SEG_e_s_n3@@';
+      const makeFragments = (parentId, itemId, first, second) => [
+        { t: `${first}${m2}${second}`, i: itemId, blockId: parentId, isV3Fragment: true, parentId, fragmentIndex: 0, fragmentCount: 2, fragmentJoinerBefore: '' },
+        { t: `${m3}${second}`, i: itemId, blockId: parentId, isV3Fragment: true, parentId, fragmentIndex: 1, fragmentCount: 2, fragmentJoinerBefore: ' ' },
+      ];
+      const b = makeFragments('b1', 'n1', 'B', 'Y');
+      const d = makeFragments('d1', 'n2', 'D', 'Q');
+      const f = makeFragments('f1', 'n3', 'F', 'S');
+      mockEngine.createIntelligentBatches = vi.fn(() => [[
+        { t: 'A', i: 'a', blockId: 'a' },
+        ...b,
+        { t: 'C', i: 'c', blockId: 'c' },
+        ...d,
+        { t: 'E', i: 'e', blockId: 'e' },
+        ...f,
+        { t: 'G', i: 'g', blockId: 'g' },
+      ]]);
+      mockProvider.translate
+        .mockResolvedValueOnce({ translatedText: [
+          'A', `B${m2}Y`, `${m3}${m3}Y`, 'C', `D${m2}Q`, `${m3}${m3}Q`, 'E', `F${m2}S`, `${m3}${m3}S`, 'G'
+        ] })
+        .mockImplementation((texts, _source, _target, options) => {
+          if (options.callPurpose === TranslationCallPurpose.PARENT_RECOVERY) {
+            return Promise.resolve({ translatedText: texts.map((item) => ({ i: item.i, text: item.text })) });
+          }
+          return Promise.resolve({ translatedText: texts });
+        });
+
+      const result = await handler.execute(
+        mockEngine,
+        { ...mockData, sourceLanguage: 'en', text: JSON.stringify([
+          { t: 'A', i: 'a', blockId: 'a' },
+          { t: `B${m2}Y ${m3}Y`, i: 'n1', blockId: 'b1' },
+          { t: 'C', i: 'c', blockId: 'c' },
+          { t: `D${m2}Q ${m3}Q`, i: 'n2', blockId: 'd1' },
+          { t: 'E', i: 'e', blockId: 'e' },
+          { t: `F${m2}S ${m3}S`, i: 'n3', blockId: 'f1' },
+          { t: 'G', i: 'g', blockId: 'g' },
+        ]) },
+        mockProvider, 'en', 'fa', 'msg-recovery-cap', mockSender
+      );
+
+      expect(result.success).toBe(false);
+      expect(mockProvider.translate.mock.calls.filter(call => call[3].callPurpose === TranslationCallPurpose.PARENT_RECOVERY)).toHaveLength(2);
+      expect(result.results.map(r => r.i)).toEqual(['a', 'n1', 'c', 'n2', 'e']);
+      expect(result.results.some(r => r.i === 'n3' || r.i === 'g')).toBe(false);
+      const updates = browser.tabs.sendMessage.mock.calls
+        .map(([, m]) => m)
+        .filter(m => m.action === MessageActions.TRANSLATION_STREAM_UPDATE);
+      expect(updates).toHaveLength(1);
+      expect(updates[0].data.data.map(d => d.i)).toEqual(['a', 'n1', 'c', 'n2', 'e']);
     });
 
     it('preserves the prefix in results without streaming when skipStreaming is set (PDF)', async () => {


### PR DESCRIPTION
## Summary

Allow structured translation batches to recover up to two independently invalid V3 parents within the same physical batch.

Previously, only the first invalid parent could be recovered. If a later parent also failed validation, already recovered/valid results were preserved, but the remaining batch was abandoned and the operation ended with partial failure.

## Changes

- Add a maximum of 2 parent recovery lifecycles per physical batch.
- Resume fragment collection after each successful recovery.
- Preserve source ordering across recovered and valid parents.
- Preserve accumulated results if a later recovery fails or the recovery cap is reached.
- Keep publication and terminal acceptance single-shot.
- Reuse the existing operation deadline and abort controller across recoveries.
- Keep existing stage-1/stage-2 recovery semantics unchanged.

## Behavior

Before:

    A → B invalid → recover B → C → D invalid
    → publish A, B', C
    → success:false

After:

    A → B invalid → recover B → C → D invalid → recover D → E
    → publish A, B', C, D', E
    → success:true

If a third parent fails, no third recovery lifecycle is attempted. The
successfully accumulated prefix is preserved and the operation reports failure.

## Scope

No changes to:

- provider recovery implementation
- accounting/statistics
- retry ownership
- conversation state
- timeout ownership
- streaming/publication contracts

## Validation

- OptimizedJsonHandler: 157 passed
- OptimizedJsonHandler integration: 3 passed
- Translation core: 449 passed
- Select Element: 478 passed
- Provider/recovery: 135 passed
- ESLint: clean
- `git diff --check`: clean