### PR TITLE
fix(page-translation): treat blank results as failed settlements

### DIFF
--- a/src/features/page-translation/PageTranslationScheduler.js
+++ b/src/features/page-translation/PageTranslationScheduler.js
@@ -449,14 +449,9 @@ export class PageTranslationScheduler extends ResourceTracker {
       batch.forEach((item, index) => {
         const translatedItem = translatedTexts[index];
 
-        // Explicit unresolved marker (isSkipped): keep original text and count as
-        // failed, never as translated. Only trust isSkipped === true; identity
-        // translations (text === source) are legitimate and resolve normally.
-        if (typeof translatedItem === 'object' && translatedItem !== null && translatedItem.isSkipped === true) {
-          item.resolve(typeof translatedItem.text === 'string' ? translatedItem.text : item.text);
-          this.failedCount++;
-          return;
-        }
+        const isExplicitlySkipped = typeof translatedItem === 'object'
+          && translatedItem !== null
+          && translatedItem.isSkipped === true;
 
         let translatedText = "";
 
@@ -474,10 +469,18 @@ export class PageTranslationScheduler extends ResourceTracker {
             translatedText = "";
           }
         } else {
-          translatedText = String(translatedItem || "");
+          translatedText = null;
         }
 
-        item.resolve(translatedText || "");
+        // Blank and non-string results are unresolved. Identity translations
+        // remain valid because only usability, not source equality, is checked.
+        if (isExplicitlySkipped || typeof translatedText !== 'string' || !translatedText.trim()) {
+          item.resolve(item.text);
+          this.failedCount++;
+          return;
+        }
+
+        item.resolve(translatedText);
         this.translatedCount++;
       });
 

--- a/src/features/page-translation/PageTranslationScheduler.test.js
+++ b/src/features/page-translation/PageTranslationScheduler.test.js
@@ -160,6 +160,110 @@ describe('PageTranslationScheduler', () => {
       expect(scheduler.translatedCount).toBe(1);
     });
 
+    it.each(['', '   ', '\n\t'])('should preserve original and count blank result as failed: %j', async (blankText) => {
+      const mockItem = { text: 'Original', resolve: vi.fn(), score: 1 };
+      scheduler.queue.push(mockItem);
+
+      PageTranslationFluidFilter.process.mockReturnValue({ batchItems: [mockItem], remainingItems: [] });
+      vi.spyOn(scheduler, '_getBatchConfig').mockResolvedValue({ providerRegistryId: 'google', targetLanguage: 'fa' });
+      safeSendMessage.mockResolvedValue({
+        success: true,
+        translatedText: JSON.stringify([blankText])
+      });
+
+      await scheduler.flush();
+
+      expect(mockItem.resolve).toHaveBeenCalledWith('Original');
+      expect(scheduler.translatedCount).toBe(0);
+      expect(scheduler.failedCount).toBe(1);
+    });
+
+    it('should preserve original and count null result as failed', async () => {
+      const mockItem = { text: 'Original', resolve: vi.fn(), score: 1 };
+      scheduler.queue.push(mockItem);
+
+      PageTranslationFluidFilter.process.mockReturnValue({ batchItems: [mockItem], remainingItems: [] });
+      vi.spyOn(scheduler, '_getBatchConfig').mockResolvedValue({ providerRegistryId: 'google', targetLanguage: 'fa' });
+      safeSendMessage.mockResolvedValue({
+        success: true,
+        translatedText: JSON.stringify([null])
+      });
+
+      await scheduler.flush();
+
+      expect(mockItem.resolve).toHaveBeenCalledWith('Original');
+      expect(scheduler.translatedCount).toBe(0);
+      expect(scheduler.failedCount).toBe(1);
+    });
+
+    it('should continue valid siblings around a blank result', async () => {
+      const itemA = { text: 'A', resolve: vi.fn(), score: 1 };
+      const itemB = { text: 'B', resolve: vi.fn(), score: 1 };
+      const itemC = { text: 'C', resolve: vi.fn(), score: 1 };
+      scheduler.queue.push(itemA, itemB, itemC);
+
+      PageTranslationFluidFilter.process.mockReturnValue({ batchItems: [itemA, itemB, itemC], remainingItems: [] });
+      vi.spyOn(scheduler, '_getBatchConfig').mockResolvedValue({ providerRegistryId: 'google', targetLanguage: 'fa' });
+      safeSendMessage.mockResolvedValue({
+        success: true,
+        translatedText: JSON.stringify(['A2', '', 'C2'])
+      });
+
+      await scheduler.flush();
+
+      expect(itemA.resolve).toHaveBeenCalledWith('A2');
+      expect(itemB.resolve).toHaveBeenCalledWith('B');
+      expect(itemC.resolve).toHaveBeenCalledWith('C2');
+      expect(scheduler.translatedCount).toBe(2);
+      expect(scheduler.failedCount).toBe(1);
+    });
+
+    it('should complete all-blank batches through failed accounting', async () => {
+      const itemA = { text: 'A', resolve: vi.fn(), score: 1 };
+      const itemB = { text: 'B', resolve: vi.fn(), score: 1 };
+      scheduler.queue.push(itemA, itemB);
+      scheduler.totalTasks = 2;
+
+      PageTranslationFluidFilter.process.mockReturnValue({ batchItems: [itemA, itemB], remainingItems: [] });
+      vi.spyOn(scheduler, '_getBatchConfig').mockResolvedValue({ providerRegistryId: 'google', targetLanguage: 'fa' });
+      safeSendMessage.mockResolvedValue({
+        success: true,
+        translatedText: JSON.stringify(['', '   '])
+      });
+
+      await scheduler.flush();
+
+      expect(itemA.resolve).toHaveBeenCalledWith('A');
+      expect(itemB.resolve).toHaveBeenCalledWith('B');
+      expect(scheduler.translatedCount).toBe(0);
+      expect(scheduler.failedCount).toBe(2);
+      expect(scheduler.translatedCount + scheduler.failedCount).toBe(scheduler.totalTasks);
+      expect(scheduler.activeFlushes).toBe(0);
+      expect(scheduler.queue).toHaveLength(0);
+    });
+
+    it('should count blank and explicit skipped results once each', async () => {
+      const itemA = { text: 'A', resolve: vi.fn(), score: 1 };
+      const itemB = { text: 'B', resolve: vi.fn(), score: 1 };
+      scheduler.queue.push(itemA, itemB);
+
+      PageTranslationFluidFilter.process.mockReturnValue({ batchItems: [itemA, itemB], remainingItems: [] });
+      vi.spyOn(scheduler, '_getBatchConfig').mockResolvedValue({ providerRegistryId: 'google', targetLanguage: 'fa' });
+      safeSendMessage.mockResolvedValue({
+        success: true,
+        translatedText: JSON.stringify(['', { text: 'B', isSkipped: true }])
+      });
+
+      await scheduler.flush();
+
+      expect(itemA.resolve).toHaveBeenCalledTimes(1);
+      expect(itemA.resolve).toHaveBeenCalledWith('A');
+      expect(itemB.resolve).toHaveBeenCalledTimes(1);
+      expect(itemB.resolve).toHaveBeenCalledWith('B');
+      expect(scheduler.translatedCount).toBe(0);
+      expect(scheduler.failedCount).toBe(2);
+    });
+
     it('should honor isSkipped items in a mixed partial result', async () => {
       const itemA = { text: 'A', resolve: vi.fn(), score: 1 };
       const itemB = { text: 'B', resolve: vi.fn(), score: 1 };


### PR DESCRIPTION
## Summary

Harden Whole Page translation settlement so unusable provider output is not reported as a successful translation.

Previously, empty, whitespace-only, or non-string results could increment `translatedCount` even though the visible page preserved the original source text. This could make translation progress and completion state report success for content that was not actually translated.

## Changes

- Treat empty strings as unresolved results.
- Treat whitespace-only strings as unresolved results.
- Treat non-string results such as `null` as unresolved.
- Preserve the original source text for unresolved items.
- Increment `failedCount` instead of `translatedCount`.
- Keep valid sibling translations processing normally.
- Preserve identity translations such as `URL → URL` as valid translations.
- Keep existing `isSkipped` behavior aligned with the same unresolved settlement semantics.

## Behavior

Before:

    ''        → translatedCount++
    '   '     → translatedCount++
    null      → translatedCount++
    'URL'     → translatedCount++

After:

    ''        → original text + failedCount++
    '   '     → original text + failedCount++
    null      → original text + failedCount++
    'URL'     → translatedCount++

Completion semantics remain unchanged:

    processedCount = translatedCount + failedCount

Therefore all-blank and partially blank batches still terminate normally
without treating unresolved items as translated.

## Scope

Changes are limited to:

- `PageTranslationScheduler.js`
- `PageTranslationScheduler.test.js`

No changes to providers, `UnifiedModeCoordinator`, `PageTranslationBridge`,
`domtranslator`, or translation lifecycle infrastructure.

## Tests

Added coverage for:

- empty output
- whitespace-only output
- newline/tab-only output
- null output
- mixed valid/blank/valid results
- all-blank batch completion
- blank combined with explicit `isSkipped`
- identity translation regression

## Validation

- PageTranslationScheduler: 18 passed
- Full page-translation suite: 115 passed
- UnifiedModeCoordinator: 41 passed
- Translation core: 449 passed
- ESLint: clean
- `git diff --check`: clean