### PR TITLE
Fix Select Element revert shortcut conflicts with website Esc handling

### DIFF
--- a/docs/technical/SELECT_ELEMENT_SYSTEM.md
+++ b/docs/technical/SELECT_ELEMENT_SYSTEM.md
@@ -86,6 +86,8 @@ The feature contract defines the complete observable behavior. Core invariants:
 - User cancellation and conflict cancellation preserve committed content.
 - Failure and cancellation do not automatically perform explicit revert.
 - Explicit revert is separate from cancellation and restores stored original state.
+- During active selection, single Esc cancels the mode and is consumed by the manager.
+- Outside active selection, global cancellation and revert require Double Esc. Both browser events remain available to the website; repeated and modifier Escape presses do not count.
 - Raw provider fragments are not feature-visible results.
 - Public feedback uses feature and shared error boundaries, not raw runtime text.
 

--- a/docs/technical/SMART_HANDLER_REGISTRATION_SYSTEM.md
+++ b/docs/technical/SMART_HANDLER_REGISTRATION_SYSTEM.md
@@ -139,12 +139,12 @@ await interactionCoordinator.initialize();
 | `textFieldIcon` | `TRANSLATE_ON_TEXT_SELECTION` | `DEFAULT_EXCLUDED_TEXT_FIELDS_ICON` + `EXCLUDED_SITES` | `focusin` |
 | `shortcut` | `ENABLE_SHORTCUT_FOR_TEXT_FIELDS` | `EXCLUDED_SITES` | `keydown` (Ctrl+/) |
 
-### Special Case: Revert (ESC)
-The Revert functionality is unique because it must work even if the user has disabled shortcuts.
-1. `SelectElementManager` emits `ELEMENT_TRANSLATIONS_AVAILABLE`.
-2. `InteractionCoordinator` sets `revertMightBeNeeded = true`.
-3. Even if `shortcut` is disabled, `InteractionCoordinator` keeps the `keydown` listener active.
-4. On `Escape`, it calls `loadFeature('shortcut', true)` (Forced Load) to execute the Revert logic.
+### Special Case: Select Element Escape
+Select Element Escape support works even if user disabled field shortcuts.
+1. Active selection owns and consumes single Esc through `SelectElementManager`.
+2. Outside selection, global cancellation and revert require non-consuming Double Esc; websites receive both events.
+3. Repeated or modifier Escape does not count.
+4. Lazy shortcut activation may delegate only its triggering event when `ShortcutManager` was not initialized; initialized managers own dispatch directly, preventing duplicate delivery.
 
 ---
 

--- a/docs/technical/contracts/FEATURE_CONTRACTS.md
+++ b/docs/technical/contracts/FEATURE_CONTRACTS.md
@@ -72,7 +72,7 @@ Additional invariants:
 | ------- | -------------- | --------------- | -------------- | ------------- | ------------------ |
 | Selection Window | none (read-only overlay) | n/a (single result) | not needed | `TranslationHandler` (window manager) | `WindowsManager.cancelCurrentTranslation` |
 | Inline Selection | none (tooltip overlay) | n/a (single result) | not needed | `TranslationHandler.performTranslation` | `HoverTranslationManager._cancelPendingHover` |
-| Select Element | `DomTranslatorAdapter` + `BlockGroupReconstructor` | yes (per-unit, A/B/C kept) | manual via `SelectElementManager.revertTranslations` | pipeline (`ErrorTypes.TRANSLATION_TIMEOUT`) | `SelectElementManager.handleKeyDown` → `deactivate({ fromCancel })` |
+| Select Element | `DomTranslatorAdapter` + `BlockGroupReconstructor` | yes (per-unit, A/B/C kept) | manual via `SelectElementManager.revertTranslations` | pipeline (`ErrorTypes.TRANSLATION_TIMEOUT`) | selection: single Esc via `SelectElementManager`; global cancellation/revert: non-consuming Double Esc |
 | Field | smart-handler replacement service | n/a (single value) | no (write-on-apply) | shared pipeline | `cancelTranslation` via `useUnifiedTranslation` / `dataStore.abortExistingRequest` |
 | Popup | none (app-owned store) | n/a (single result) | not needed | shared pipeline | `cancelTranslation` (silent reset) |
 | Sidepanel | none (app-owned store) | n/a (single result) | not needed | shared pipeline | `cancelTranslation` |
@@ -123,7 +123,7 @@ Modes: `Select_Element`.
 - **Partial success scenario: A success, B failure, C success** → nodes A and C stay translated; node B remains original. No rollback of completed independent units on a later provider failure.
 - **Raw fragments suppressed** at the adapter boundary (`isSplitFragment` / `isV3Fragment` → skip before any write).
 - **Duplicate logical identities applied once** via UID + `processedUnits` set.
-- **Esc / user cancellation**: `SelectElementManager.handleKeyDown` → `deactivate({ fromCancel: true })` → `cancelTranslation`. It does **not** revert already-applied partial translations.
+- **Esc / user cancellation**: during active selection, `SelectElementManager.handleKeyDown` owns and consumes single Esc to cancel the mode. Outside selection, global cancellation or revert requires two plain Esc presses within 400ms and never consumes either event. Repeated or modifier Escape does not count. Cancellation does **not** revert already-applied partial translations.
 - **Revert** (`SelectElementManager.revertTranslations`) restores the **original text and direction metadata** (`restoreElementDirection`, removes `data-has-original`).
 - **Block-group reconstruction is atomic.** `BlockGroupReconstructor` validates first (segment markers, node connectivity/content), then commits all units synchronously. Atomicity is enforced through validation plus transactional rollback: validation occurs before mutation, mutation may then begin, and a mutation-phase failure triggers best-effort rollback of the affected transaction. Rollback failures are aggregated as secondary diagnostics and never replace the primary mutation failure.
 

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -1407,7 +1407,7 @@
     "message": "Revert"
   },
   "popup_revert_title_icon": {
-    "message": "Revert (Esc Key)"
+    "message": "Revert (Esc x2)"
   },
   "popup_clear_storage_alt_icon": {
     "message": "Clear"
@@ -1569,7 +1569,7 @@
     "message": "Clear fields"
   },
   "SIDEPANEL_REVERT_TOOLTIP": {
-    "message": "Revert (Esc Key)"
+    "message": "Revert (Esc x2)"
   },
   "SIDEPANEL_SELECT_ELEMENT_TOOLTIP": {
     "message": "Select Element"

--- a/src/_locales/fa/messages.json
+++ b/src/_locales/fa/messages.json
@@ -1407,7 +1407,7 @@
     "message": "بازگرداندن"
   },
   "popup_revert_title_icon": {
-    "message": "بازگرداندن (کلید Esc)"
+    "message": "بازگرداندن (Esc x2)"
   },
   "popup_clear_storage_alt_icon": {
     "message": "پاک کردن"
@@ -1569,7 +1569,7 @@
     "message": "خالی کردن"
   },
   "SIDEPANEL_REVERT_TOOLTIP": {
-    "message": "بازگردانی (Esc کلید)"
+    "message": "بازگرداندن (Esc x2)"
   },
   "SIDEPANEL_SELECT_ELEMENT_TOOLTIP": {
     "message": "انتخاب المان"

--- a/src/_locales/ja/messages.json
+++ b/src/_locales/ja/messages.json
@@ -1407,7 +1407,7 @@
     "message": "元に戻す"
   },
   "popup_revert_title_icon": {
-    "message": "元に戻す（Escキー）"
+    "message": "元に戻す（Esc x2）"
   },
   "popup_clear_storage_alt_icon": {
     "message": "クリア"
@@ -1569,7 +1569,7 @@
     "message": "フィールドをクリア"
   },
   "SIDEPANEL_REVERT_TOOLTIP": {
-    "message": "元に戻す（Escキー）"
+    "message": "元に戻す（Esc x2）"
   },
   "SIDEPANEL_SELECT_ELEMENT_TOOLTIP": {
     "message": "要素を選択"

--- a/src/core/content-scripts/CtrlSlashDispatch.integration.test.js
+++ b/src/core/content-scripts/CtrlSlashDispatch.integration.test.js
@@ -245,6 +245,34 @@ describe('Ctrl+/ dispatch characterization', () => {
     expect(mocks.sendMessage).not.toHaveBeenCalled();
   });
 
+  it('does not manually redispatch Escape after ShortcutManager is initialized', async () => {
+    await activateShortcutWiring();
+    const dispatchSpy = vi.spyOn(shortcutManager, 'handleKeyboardEvent');
+    const event = createEvent('Escape');
+
+    coordinator.revertMightBeNeeded = true;
+    await coordinator._handleKeyboardInteraction(event);
+
+    expect(dispatchSpy).not.toHaveBeenCalled();
+    dispatchSpy.mockRestore();
+  });
+
+  it('delegates first lazy Escape once after ShortcutManager initializes', async () => {
+    mocks.loadFeature.mockImplementationOnce(async () => {
+      handler = ShortcutHandler.getInstance({ featureManager: {} });
+      await handler.activate();
+      return handler;
+    });
+    await coordinator.initialize();
+    coordinator.revertMightBeNeeded = true;
+    const dispatchSpy = vi.spyOn(shortcutManager, 'handleKeyboardEvent');
+
+    await coordinator._handleKeyboardInteraction(createEvent('Escape'));
+
+    expect(dispatchSpy).toHaveBeenCalledTimes(1);
+    dispatchSpy.mockRestore();
+  });
+
   it('characterizes first-event lazy activation separately', async () => {
     let lazyHandler;
     mocks.loadFeature.mockImplementationOnce(async () => {

--- a/src/core/content-scripts/InteractionCoordinator.js
+++ b/src/core/content-scripts/InteractionCoordinator.js
@@ -119,12 +119,10 @@ class InteractionCoordinator {
     const shortcutManagerWasInitialized = shortcutManager.initialized;
     const { loadFeature } = await import('./chunks/lazy-features.js');
     
-    // Load shortcut feature on demand. ShortcutManager owns Ctrl+/ dispatch;
-    // only invoke it directly when this event triggered first-time activation.
-    const handler = await loadFeature('shortcut', isEscape);
-    if (isEscape && handler && typeof handler.handleKeyboardEvent === 'function') {
-      handler.handleKeyboardEvent(event);
-    } else if (isMainShortcut && !shortcutManagerWasInitialized && shortcutManager.initialized) {
+    // ShortcutManager owns dispatch once initialized. First lazy activation
+    // happens after this event has propagated, so delegate only that event once.
+    await loadFeature('shortcut', isEscape);
+    if (!shortcutManagerWasInitialized && shortcutManager.initialized) {
       shortcutManager.handleKeyboardEvent(event);
     }
   }

--- a/src/core/managers/content/shortcuts/RevertShortcut.js
+++ b/src/core/managers/content/shortcuts/RevertShortcut.js
@@ -4,6 +4,7 @@ import { LOG_COMPONENTS } from '@/shared/logging/logConstants.js';
 // We need to get it via FeatureManager or use alternative approaches
 
 const logger = getScopedLogger(LOG_COMPONENTS.SHORTCUTS, 'RevertShortcut');
+const DOUBLE_ESCAPE_INTERVAL = 400;
 
 /**
  * Get active SelectElementManager via FeatureManager
@@ -32,7 +33,8 @@ async function getActiveSelectElementManager() {
 export class RevertShortcut {
   constructor() {
     this.key = 'Escape';
-    this.description = 'Revert all translations on the page';
+    this.description = 'Double Escape to cancel or revert Select Element translations';
+    this.lastEscapeAt = null;
   }
 
   /**
@@ -41,9 +43,34 @@ export class RevertShortcut {
    * @returns {Promise<boolean>} Whether to execute the shortcut
    */
   async shouldExecute(event) {
-    // This shortcut should always be checked on Escape key press.
-    // The decision to cancel or revert is handled in the execute method.
-    return event.key === 'Escape' || event.code === 'Escape';
+    if (!this.isPlainEscape(event)) return false;
+
+    const now = Date.now();
+    const isDoubleEscape = this.lastEscapeAt !== null
+      && now - this.lastEscapeAt <= DOUBLE_ESCAPE_INTERVAL;
+    this.lastEscapeAt = isDoubleEscape ? null : now;
+    return isDoubleEscape;
+  }
+
+  /**
+   * Preserve native Escape behavior even when Double Escape triggers an action.
+   * @returns {boolean} Whether ShortcutManager should consume the event
+   */
+  shouldConsumeEvent() {
+    return false;
+  }
+
+  isPlainEscape(event) {
+    return (event.key === 'Escape' || event.code === 'Escape')
+      && !event.repeat
+      && !event.ctrlKey
+      && !event.altKey
+      && !event.shiftKey
+      && !event.metaKey;
+  }
+
+  resetDoubleEscape() {
+    this.lastEscapeAt = null;
   }
 
   /**
@@ -178,7 +205,11 @@ export class RevertShortcut {
       key: this.key,
       description: this.description,
       type: 'RevertShortcut',
-      triggers: ['Escape key press with translations present']
+      triggers: ['Double Escape with Select Element translations present']
     };
+  }
+
+  cleanup() {
+    this.resetDoubleEscape();
   }
 }

--- a/src/core/managers/content/shortcuts/RevertShortcut.test.js
+++ b/src/core/managers/content/shortcuts/RevertShortcut.test.js
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
 vi.mock('@/shared/logging/logConstants.js', () => ({
   LOG_COMPONENTS: { SHORTCUTS: 'Shortcuts' }
@@ -31,6 +31,9 @@ vi.mock('@/handlers/content/RevertHandler.js', () => ({
   }
 }));
 
+import { sendMessage } from '@/shared/messaging/core/UnifiedMessaging.js';
+import { revertHandler } from '@/handlers/content/RevertHandler.js';
+
 describe('RevertShortcut ESC-cancel ownership', () => {
   let RevertShortcut;
   let deactivate;
@@ -38,6 +41,8 @@ describe('RevertShortcut ESC-cancel ownership', () => {
 
   beforeEach(async () => {
     vi.clearAllMocks();
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-08-29T00:00:00Z'));
     deactivate = vi.fn(async () => {});
     featureManager = {
       getFeatureHandler: vi.fn((name) =>
@@ -50,6 +55,64 @@ describe('RevertShortcut ESC-cancel ownership', () => {
 
     const module = await import('./RevertShortcut.js');
     RevertShortcut = module.RevertShortcut;
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  function escapeEvent(overrides = {}) {
+    return {
+      key: 'Escape',
+      code: 'Escape',
+      repeat: false,
+      ctrlKey: false,
+      altKey: false,
+      shiftKey: false,
+      metaKey: false,
+      ...overrides,
+    };
+  }
+
+  it('requires two plain Escape presses within 400ms', async () => {
+    const shortcut = new RevertShortcut();
+
+    await expect(shortcut.shouldExecute(escapeEvent())).resolves.toBe(false);
+    vi.advanceTimersByTime(400);
+    await expect(shortcut.shouldExecute(escapeEvent())).resolves.toBe(true);
+  });
+
+  it('treats a slow Escape as a new first press', async () => {
+    const shortcut = new RevertShortcut();
+
+    await shortcut.shouldExecute(escapeEvent());
+    vi.advanceTimersByTime(401);
+    await expect(shortcut.shouldExecute(escapeEvent())).resolves.toBe(false);
+    vi.advanceTimersByTime(400);
+    await expect(shortcut.shouldExecute(escapeEvent())).resolves.toBe(true);
+  });
+
+  it('ignores repeated and modified Escape without corrupting a valid sequence', async () => {
+    const shortcut = new RevertShortcut();
+
+    await shortcut.shouldExecute(escapeEvent());
+    await expect(shortcut.shouldExecute(escapeEvent({ repeat: true }))).resolves.toBe(false);
+    await expect(shortcut.shouldExecute(escapeEvent({ ctrlKey: true }))).resolves.toBe(false);
+    await expect(shortcut.shouldExecute(escapeEvent({ altKey: true }))).resolves.toBe(false);
+    await expect(shortcut.shouldExecute(escapeEvent({ shiftKey: true }))).resolves.toBe(false);
+    await expect(shortcut.shouldExecute(escapeEvent({ metaKey: true }))).resolves.toBe(false);
+    vi.advanceTimersByTime(400);
+    await expect(shortcut.shouldExecute(escapeEvent())).resolves.toBe(true);
+  });
+
+  it('resets a pending sequence during shortcut cleanup', async () => {
+    const shortcut = new RevertShortcut();
+
+    await shortcut.shouldExecute(escapeEvent());
+    shortcut.cleanup();
+    vi.advanceTimersByTime(100);
+
+    await expect(shortcut.shouldExecute(escapeEvent())).resolves.toBe(false);
   });
 
   it('requests tab-wide Select Element deactivation on ESC during active translation', async () => {
@@ -68,6 +131,52 @@ describe('RevertShortcut ESC-cancel ownership', () => {
     );
     // Dead flag must not be reintroduced.
     expect(deactivate.mock.calls[0][0]).not.toHaveProperty('fromCancel');
+  });
+
+  it('uses the existing cancellation flow once after a valid Double Escape', async () => {
+    window.isTranslationInProgress = true;
+    const shortcut = new RevertShortcut();
+
+    await shortcut.shouldExecute(escapeEvent());
+    vi.advanceTimersByTime(100);
+    expect(await shortcut.shouldExecute(escapeEvent())).toBe(true);
+    await shortcut.execute();
+
+    expect(deactivate).toHaveBeenCalledTimes(1);
+  });
+
+  it('reverts completed translations once and preserves the iframe broadcast', async () => {
+    window.isTranslationInProgress = false;
+    featureManager.getFeatureHandler.mockReturnValue({ deactivate, isActive: false });
+    revertHandler.executeRevert.mockResolvedValue({ success: true, revertedCount: 1 });
+    const shortcut = new RevertShortcut();
+
+    await shortcut.shouldExecute(escapeEvent());
+    vi.advanceTimersByTime(100);
+    await shortcut.shouldExecute(escapeEvent());
+    await shortcut.execute();
+
+    expect(revertHandler.executeRevert).toHaveBeenCalledTimes(1);
+    expect(sendMessage).toHaveBeenCalledWith(expect.objectContaining({
+      action: 'REVERT_SELECT_ELEMENT_MODE',
+    }));
+  });
+
+  it('preserves the iframe broadcast when this frame has no translations to revert', async () => {
+    window.isTranslationInProgress = false;
+    featureManager.getFeatureHandler.mockReturnValue({ deactivate, isActive: false });
+    revertHandler.executeRevert.mockResolvedValue({ success: true, revertedCount: 0 });
+    const shortcut = new RevertShortcut();
+
+    await shortcut.shouldExecute(escapeEvent());
+    vi.advanceTimersByTime(100);
+    await shortcut.shouldExecute(escapeEvent());
+    await shortcut.execute();
+
+    expect(revertHandler.executeRevert).toHaveBeenCalledTimes(1);
+    expect(sendMessage).toHaveBeenCalledWith(expect.objectContaining({
+      action: 'REVERT_SELECT_ELEMENT_MODE',
+    }));
   });
 
   it('defers to SelectElementManager while it owns the ESC key', async () => {

--- a/src/core/managers/content/shortcuts/ShortcutManager.js
+++ b/src/core/managers/content/shortcuts/ShortcutManager.js
@@ -78,7 +78,8 @@ export class ShortcutManager extends ResourceTracker {
     const { FieldShortcutManager } = await import('@/features/text-field-interaction/managers/FieldShortcutManager.js');
     
     // Register ESC shortcut for revert
-    this.registerShortcut('Escape', new RevertShortcut());
+    this.revertShortcut = new RevertShortcut();
+    this.registerShortcut('Escape', this.revertShortcut);
     
     // Register Ctrl+/ shortcut for translation (will be updated dynamically)
     const ctrlSlashShortcut = new FieldShortcutManager();
@@ -229,10 +230,15 @@ export class ShortcutManager extends ResourceTracker {
         return;
       }
 
-      // Prevent default behavior
-      event.preventDefault();
-      event.stopPropagation();
-      event.stopImmediatePropagation();
+      // Handlers may opt out when browser-native behavior must remain available.
+      const shouldConsumeEvent = typeof handler.shouldConsumeEvent === 'function'
+        ? await handler.shouldConsumeEvent(event)
+        : true;
+      if (shouldConsumeEvent) {
+        event.preventDefault();
+        event.stopPropagation();
+        event.stopImmediatePropagation();
+      }
 
       // Execute shortcut
       const result = await handler.execute(event);
@@ -296,6 +302,9 @@ export class ShortcutManager extends ResourceTracker {
    * Cleanup shortcut manager
    */
   cleanup() {
+    this.revertShortcut?.cleanup();
+    this.revertShortcut = null;
+
     // Clear shortcuts
     this.shortcuts.clear();
     this.listeners.clear();

--- a/src/core/managers/content/shortcuts/ShortcutManager.test.js
+++ b/src/core/managers/content/shortcuts/ShortcutManager.test.js
@@ -1,0 +1,72 @@
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/shared/logging/logConstants.js', () => ({
+  LOG_COMPONENTS: { SHORTCUTS: 'Shortcuts' },
+}));
+
+vi.mock('@/shared/logging/logger.js', () => ({
+  getScopedLogger: vi.fn(() => ({ debug: vi.fn(), error: vi.fn(), operation: vi.fn() })),
+}));
+
+vi.mock('@/core/memory/ResourceTracker.js', () => ({
+  default: class ResourceTracker {
+    cleanup() {}
+  },
+}));
+
+vi.mock('../KeyboardStateManager.js', () => ({
+  KeyboardStateManager: class KeyboardStateManager {},
+}));
+
+import { ShortcutManager } from './ShortcutManager.js';
+
+describe('ShortcutManager event consumption', () => {
+  it('executes a non-consuming handler without claiming the browser event', async () => {
+    const manager = new ShortcutManager();
+    manager.initialized = true;
+    const execute = vi.fn();
+    manager.registerShortcut('Escape', {
+      shouldExecute: vi.fn(async () => true),
+      shouldConsumeEvent: vi.fn(() => false),
+      execute,
+    });
+    const event = new KeyboardEvent('keydown', { key: 'Escape', bubbles: true, cancelable: true });
+    const preventDefault = vi.spyOn(event, 'preventDefault');
+    const stopPropagation = vi.spyOn(event, 'stopPropagation');
+    const stopImmediatePropagation = vi.spyOn(event, 'stopImmediatePropagation');
+
+    await manager.handleKeyboardEvent(event);
+
+    expect(execute).toHaveBeenCalledTimes(1);
+    expect(event.defaultPrevented).toBe(false);
+    expect(preventDefault).not.toHaveBeenCalled();
+    expect(stopPropagation).not.toHaveBeenCalled();
+    expect(stopImmediatePropagation).not.toHaveBeenCalled();
+  });
+
+  it('preserves consuming behavior for existing handlers', async () => {
+    const manager = new ShortcutManager();
+    manager.initialized = true;
+    const execute = vi.fn();
+    manager.registerShortcut('Ctrl+/', { shouldExecute: vi.fn(async () => true), execute });
+    const event = new KeyboardEvent('keydown', { key: '/', ctrlKey: true, bubbles: true, cancelable: true });
+
+    await manager.handleKeyboardEvent(event);
+
+    expect(execute).toHaveBeenCalledTimes(1);
+    expect(event.defaultPrevented).toBe(true);
+  });
+
+  it('resets only RevertShortcut state during manager cleanup', () => {
+    const manager = new ShortcutManager();
+    manager.revertShortcut = { cleanup: vi.fn() };
+    const fieldShortcut = { cleanup: vi.fn() };
+    manager.registerShortcut('Escape', manager.revertShortcut);
+    manager.registerShortcut('Ctrl+/', fieldShortcut);
+
+    manager.cleanup();
+
+    expect(manager.revertShortcut).toBeNull();
+    expect(fieldShortcut.cleanup).not.toHaveBeenCalled();
+  });
+});

--- a/src/features/element-selection/SelectElementManager.test.js
+++ b/src/features/element-selection/SelectElementManager.test.js
@@ -1676,9 +1676,16 @@ describe('SelectElementManager', () => {
     });
 
     it('should handle ESC key to deactivate', async () => {
-      const event = new KeyboardEvent('keydown', { key: 'Escape', bubbles: true });
+      const event = new KeyboardEvent('keydown', { key: 'Escape', bubbles: true, cancelable: true });
+      const preventDefault = vi.spyOn(event, 'preventDefault');
+      const stopPropagation = vi.spyOn(event, 'stopPropagation');
+      const stopImmediatePropagation = vi.spyOn(event, 'stopImmediatePropagation');
       manager.handleKeyDown(event);
       await vi.waitFor(() => expect(manager.isActive).toBe(false));
+      expect(event.defaultPrevented).toBe(true);
+      expect(preventDefault).toHaveBeenCalled();
+      expect(stopPropagation).toHaveBeenCalled();
+      expect(stopImmediatePropagation).toHaveBeenCalled();
     });
 
     it('should handle mouseover to highlight element', () => {


### PR DESCRIPTION
## Summary

* Changed global Select Element cancel/revert from single `Esc` to `Esc x2`.
* Kept single `Esc` for cancelling active Select Element selection.
* Made global Double Esc non-consuming so websites still receive both key events.
* Ignored repeated and modified Escape presses.
* Fixed duplicate Escape dispatch during lazy shortcut initialization.
* Preserved cross-frame revert behavior.
* Updated Popup and Sidepanel Revert tooltips for `Esc x2`.
* Updated English, Persian, and Japanese locale strings.

## Validation

* Focused tests passed.
* ESLint passed.
* i18n validation passed.
* `git diff --check` passed.

Refs #177
