### PR TITLE
Fix Mouse Hover modifier trigger behavior and platform shortcuts

### DIFF
--- a/docs/technical/ARCHITECTURE.md
+++ b/docs/technical/ARCHITECTURE.md
@@ -1087,7 +1087,7 @@ The mouse on hover system provides a high-performance, "zero-click" translation 
 - **HoverTextDetector**: A specialized engine that uses browser range APIs for high-precision detection of words, sentences, or containers.
 - **Rectangle Cache**: An optimization layer that stores the bounding box of the detected text, skipping expensive DOM lookups as long as the mouse remains within the same area.
 - **Shadow DOM Tooltip**: Renders the translation within an isolated UI Host component (`MouseHoverTooltip.vue`), using smart positioning to avoid viewport clipping.
-- **Modifier Key Integration**: Supports standalone Ctrl/Alt/Shift press/release gestures; successful release triggers translation, while normal shortcuts invalidate the gesture.
+- **Modifier Key Integration**: Supports standalone primary/control/Alt/Shift press/release gestures; primary resolves to Control on Windows/Linux or Command on macOS, while control remains explicit Control. Successful release triggers translation, while normal shortcuts invalidate the gesture.
 
 ### Documentation
 For detailed information on detection scopes, performance benchmarks, and positioning logic, refer to the **[Mouse on Hover System Documentation](MOUSE_HOVER_SYSTEM.md)**.

--- a/docs/technical/ARCHITECTURE.md
+++ b/docs/technical/ARCHITECTURE.md
@@ -1087,7 +1087,7 @@ The mouse on hover system provides a high-performance, "zero-click" translation 
 - **HoverTextDetector**: A specialized engine that uses browser range APIs for high-precision detection of words, sentences, or containers.
 - **Rectangle Cache**: An optimization layer that stores the bounding box of the detected text, skipping expensive DOM lookups as long as the mouse remains within the same area.
 - **Shadow DOM Tooltip**: Renders the translation within an isolated UI Host component (`MouseHoverTooltip.vue`), using smart positioning to avoid viewport clipping.
-- **Modifier Key Integration**: Supports instant translation when pressing Ctrl/Alt/Shift while hovering over text.
+- **Modifier Key Integration**: Supports standalone Ctrl/Alt/Shift press/release gestures; successful release triggers translation, while normal shortcuts invalidate the gesture.
 
 ### Documentation
 For detailed information on detection scopes, performance benchmarks, and positioning logic, refer to the **[Mouse on Hover System Documentation](MOUSE_HOVER_SYSTEM.md)**.

--- a/docs/technical/MOUSE_HOVER_SYSTEM.md
+++ b/docs/technical/MOUSE_HOVER_SYSTEM.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-The **Mouse on Hover** system provides a highly responsive, "zero-click" translation experience. Users can translate words, sentences, or entire containers simply by hovering their mouse over text. The system supports various triggers (including modifier keys like Ctrl/Alt/Shift), intelligent text detection, and a high-performance "Rectangle Cache" to minimize CPU overhead. The UI is rendered within a isolated Shadow DOM tooltip for a seamless look and feel.
+The **Mouse on Hover** system provides a highly responsive, "zero-click" translation experience. Users can translate words, sentences, or entire containers simply by hovering their mouse over text. The system supports various triggers (including primary, Control, Alt, and Shift modifiers), intelligent text detection, and a high-performance "Rectangle Cache" to minimize CPU overhead. The UI is rendered within a isolated Shadow DOM tooltip for a seamless look and feel.
 
 ## Architecture
 
@@ -77,9 +77,9 @@ To maintain 60fps performance on complex pages:
 
 ## Modifier Trigger Semantics
 
-For `ctrl`, `alt`, and `shift` trigger modes, translation activates only after a standalone modifier press is released. Normal keyboard shortcuts invalidate the gesture, so `Ctrl+A`, `Ctrl+C`, `Ctrl+F`, `Shift+A`, and modifier combinations do not translate. Pointer interaction, wheel input, window blur, and hidden-document state also invalidate pending gestures.
+For `primary`, `control`, `alt`, and `shift` trigger modes, translation activates only after a standalone modifier press is released. `primary` resolves to Control on Windows/Linux and Meta/Command on macOS. `control` always resolves to physical/logical Control, including explicit Control on macOS. Normal keyboard shortcuts invalidate the gesture, so `Ctrl+A`, `Command+A`, `Ctrl+C`, `Ctrl+F`, `Shift+A`, and modifier combinations do not translate. Pointer interaction, wheel input, window blur, and hidden-document state also invalidate pending gestures.
 
-Mouse movement updates the latest cursor event but does not independently schedule translation in modifier modes. A `ctrl` trigger accepts both `Control` and `Meta` key identities for macOS compatibility. Editable targets never create or complete modifier gestures.
+Mouse movement updates the latest cursor event but does not independently schedule translation in modifier modes. Editable targets never create or complete modifier gestures.
 
 ## Configuration & Settings
 
@@ -88,11 +88,13 @@ Behavior is fully customizable via the **Activation Tab** in the Options Page:
 | Setting Key | Default | Description |
 |-------------|---------|-------------|
 | `MOUSE_HOVER_SCOPE` | `container` | Detection depth: `word`, `sentence`, or `container`. |
-| `MOUSE_HOVER_TRIGGER` | `ctrl` | Trigger mode: `hover`, `ctrl`, `alt`, or `shift`. |
+| `MOUSE_HOVER_TRIGGER` | `primary` | Trigger mode: `hover`, `primary`, `control`, `alt`, or `shift`. `primary` is Control on Windows/Linux and Command on macOS; `control` remains explicit Control on macOS. |
 | `MOUSE_HOVER_DELAY` | `500ms` | Wait time before starting translation in normal `hover` trigger mode. Modifier-release activation does not use this setting. |
 | `MOUSE_HOVER_AUTO_CLOSE` | `mouseleave` | Close behavior: `mouseleave` or `timer`. |
 | `MOUSE_HOVER_TIMER_DURATION`| `3000ms` | Visibility duration if `timer` mode is selected. |
 | `MOUSE_HOVER_SHOW_CONTAINER_BORDER` | `true` | Visual outline for the 'container' scope. |
+
+Legacy `MOUSE_HOVER_TRIGGER=ctrl` settings migrate to `primary`.
 
 ## Feature Lifecycle
 

--- a/docs/technical/MOUSE_HOVER_SYSTEM.md
+++ b/docs/technical/MOUSE_HOVER_SYSTEM.md
@@ -87,8 +87,8 @@ Behavior is fully customizable via the **Activation Tab** in the Options Page:
 
 | Setting Key | Default | Description |
 |-------------|---------|-------------|
-| `MOUSE_HOVER_SCOPE` | `sentence` | Detection depth: `word`, `sentence`, or `container`. |
-| `MOUSE_HOVER_TRIGGER` | `hover` | Trigger mode: `hover`, `ctrl`, `alt`, or `shift`. |
+| `MOUSE_HOVER_SCOPE` | `container` | Detection depth: `word`, `sentence`, or `container`. |
+| `MOUSE_HOVER_TRIGGER` | `ctrl` | Trigger mode: `hover`, `ctrl`, `alt`, or `shift`. |
 | `MOUSE_HOVER_DELAY` | `500ms` | Wait time before starting translation in normal `hover` trigger mode. Modifier-release activation does not use this setting. |
 | `MOUSE_HOVER_AUTO_CLOSE` | `mouseleave` | Close behavior: `mouseleave` or `timer`. |
 | `MOUSE_HOVER_TIMER_DURATION`| `3000ms` | Visibility duration if `timer` mode is selected. |

--- a/docs/technical/MOUSE_HOVER_SYSTEM.md
+++ b/docs/technical/MOUSE_HOVER_SYSTEM.md
@@ -9,7 +9,7 @@ The **Mouse on Hover** system provides a highly responsive, "zero-click" transla
 The system follows the **Autonomous Feature Pattern**, isolating logic from the core while integrating deeply with the extension's translation and messaging layers. It uses an **Event-Driven & Streaming** model for high responsiveness.
 
 ```
-Mouse Move / Key Down → HoverTranslationManager (Orchestrator)
+Mouse Move / Modifier Key Press + Release → HoverTranslationManager (Orchestrator)
      ↓
      ├─→ Rectangle Cache (Hit-test optimization)
      ├─→ Request Cancellation (Prevent race conditions)
@@ -31,8 +31,8 @@ Mouse Move / Key Down → HoverTranslationManager (Orchestrator)
 The **Central Coordinator** managing the feature lifecycle and interaction logic.
 
 **Responsibilities:**
-- Event Orchestration: Listens to global `mousemove`, `mouseleave`, and `keydown` events.
-- Trigger Validation: Checks if the configured trigger (e.g., Ctrl + Hover) is met.
+- Event Orchestration: Listens to global mouse, keyboard, pointer, wheel, focus, and visibility events.
+- Trigger Validation: Requires a standalone configured modifier press and release; conflicting interaction invalidates the gesture.
 - **Request Management**: Automatically cancels previous translation requests when a new hover is triggered to prevent race conditions.
 - **Streaming Coordination**: Registers handlers for streaming updates via `ContentScriptIntegration`.
 - Optimization: Implements a "Rectangle Cache" to skip expensive DOM lookups when the mouse stays within the same text block.
@@ -42,7 +42,7 @@ The **Central Coordinator** managing the feature lifecycle and interaction logic
 |--------|-------------|
 | `activate()` / `deactivate()` | Lifecycle control via `FeatureManager` |
 | `handleMouseMove(event)` | Main entry point for detection with debouncing |
-| `handleKeyDown(event)` | Support for modifier-key triggers (e.g., press Ctrl while hovering) |
+| `handleKeyDown(event)` / `handleKeyUp(event)` | Recognizes standalone modifier gestures and triggers after release |
 | `_processHover(event)` | Orchestrates detection, cancellation, streaming registration, and translation |
 | `_removeBorder()` | Safely restores the original style of highlighted containers |
 
@@ -75,6 +75,12 @@ To maintain 60fps performance on complex pages:
 3. If it is, all expensive detection logic and timers are skipped (CPU cost: near zero).
 4. The cache is invalidated immediately when moving to empty space or when the tooltip closes.
 
+## Modifier Trigger Semantics
+
+For `ctrl`, `alt`, and `shift` trigger modes, translation activates only after a standalone modifier press is released. Normal keyboard shortcuts invalidate the gesture, so `Ctrl+A`, `Ctrl+C`, `Ctrl+F`, `Shift+A`, and modifier combinations do not translate. Pointer interaction, wheel input, window blur, and hidden-document state also invalidate pending gestures.
+
+Mouse movement updates the latest cursor event but does not independently schedule translation in modifier modes. A `ctrl` trigger accepts both `Control` and `Meta` key identities for macOS compatibility. Editable targets never create or complete modifier gestures.
+
 ## Configuration & Settings
 
 Behavior is fully customizable via the **Activation Tab** in the Options Page:
@@ -83,14 +89,14 @@ Behavior is fully customizable via the **Activation Tab** in the Options Page:
 |-------------|---------|-------------|
 | `MOUSE_HOVER_SCOPE` | `sentence` | Detection depth: `word`, `sentence`, or `container`. |
 | `MOUSE_HOVER_TRIGGER` | `hover` | Trigger mode: `hover`, `ctrl`, `alt`, or `shift`. |
-| `MOUSE_HOVER_DELAY` | `500ms` | Wait time before starting translation. |
+| `MOUSE_HOVER_DELAY` | `500ms` | Wait time before starting translation in normal `hover` trigger mode. Modifier-release activation does not use this setting. |
 | `MOUSE_HOVER_AUTO_CLOSE` | `mouseleave` | Close behavior: `mouseleave` or `timer`. |
 | `MOUSE_HOVER_TIMER_DURATION`| `3000ms` | Visibility duration if `timer` mode is selected. |
 | `MOUSE_HOVER_SHOW_CONTAINER_BORDER` | `true` | Visual outline for the 'container' scope. |
 
 ## Feature Lifecycle
 
-1. **Detection**: User hovers/presses modifier. `HoverTextDetector` finds text.
+1. **Detection**: User hovers or completes a standalone modifier gesture. `HoverTextDetector` finds text.
 2. **Registration**: `HoverTranslationManager` cancels old requests and registers a new streaming handler via `ContentScriptIntegration`.
 3. **Request**: Sends a `TRANSLATE` request to the background.
 4. **Streaming Response**: Background returns progressive text chunks.

--- a/docs/technical/contracts/FEATURE_CONTRACTS.md
+++ b/docs/technical/contracts/FEATURE_CONTRACTS.md
@@ -110,6 +110,7 @@ Modes: hover / mouse-on-hover inline tooltip.
 - **Loading UI settles on success / error / timeout / cancel.** Streaming settles via `isStreaming`; error → `showError`; timeout → `showError`; cancel → ignored (no UI error) and the tooltip hides.
 - **Duplicate result/display prevented.** Ready only emitted when message id matches; a redundant (source-equal) result hides the tooltip rather than displaying.
 - **Late result cannot recreate a dismissed box.** `_cancelPendingHover` bumps `messageId`; old resolve/reject does not match.
+- **Modifier trigger intent is standalone.** `ctrl`, `alt`, and `shift` modes activate only after a standalone modifier press is released; normal keyboard shortcuts invalidate the gesture. Mouse movement updates position but does not independently schedule modifier-mode translation.
 
 ---
 

--- a/docs/technical/contracts/FEATURE_CONTRACTS.md
+++ b/docs/technical/contracts/FEATURE_CONTRACTS.md
@@ -110,7 +110,7 @@ Modes: hover / mouse-on-hover inline tooltip.
 - **Loading UI settles on success / error / timeout / cancel.** Streaming settles via `isStreaming`; error → `showError`; timeout → `showError`; cancel → ignored (no UI error) and the tooltip hides.
 - **Duplicate result/display prevented.** Ready only emitted when message id matches; a redundant (source-equal) result hides the tooltip rather than displaying.
 - **Late result cannot recreate a dismissed box.** `_cancelPendingHover` bumps `messageId`; old resolve/reject does not match.
-- **Modifier trigger intent is standalone.** `ctrl`, `alt`, and `shift` modes activate only after a standalone modifier press is released; normal keyboard shortcuts invalidate the gesture. Mouse movement updates position but does not independently schedule modifier-mode translation.
+- **Modifier trigger intent is standalone.** `primary`, `control`, `alt`, and `shift` modes activate only after a standalone modifier press is released; `primary` resolves to Control on Windows/Linux and Command on macOS, while `control` remains explicit Control. Normal keyboard shortcuts invalidate the gesture. Mouse movement updates position but does not independently schedule modifier-mode translation.
 
 ---
 

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -473,17 +473,20 @@
   "mouse_hover_trigger_hover": {
     "message": "Immediate (Hover)"
   },
-  "mouse_hover_trigger_ctrl": {
+  "mouse_hover_trigger_primary": {
     "message": "Ctrl"
+  },
+  "mouse_hover_trigger_primary_mac": {
+    "message": "Command ⌘"
+  },
+  "mouse_hover_trigger_control": {
+    "message": "Control ⌃"
   },
   "mouse_hover_trigger_alt": {
     "message": "Alt"
   },
   "mouse_hover_trigger_shift": {
     "message": "Shift"
-  },
-  "mouse_hover_trigger_ctrl_mac": {
-    "message": "Command ⌘ / Control ⌃"
   },
   "mouse_hover_trigger_alt_mac": {
     "message": "Option ⌥"

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -474,13 +474,22 @@
     "message": "Immediate (Hover)"
   },
   "mouse_hover_trigger_ctrl": {
-    "message": "Ctrl + Hover"
+    "message": "Ctrl"
   },
   "mouse_hover_trigger_alt": {
-    "message": "Alt + Hover"
+    "message": "Alt"
   },
   "mouse_hover_trigger_shift": {
-    "message": "Shift + Hover"
+    "message": "Shift"
+  },
+  "mouse_hover_trigger_ctrl_mac": {
+    "message": "Command ⌘ / Control ⌃"
+  },
+  "mouse_hover_trigger_alt_mac": {
+    "message": "Option ⌥"
+  },
+  "mouse_hover_trigger_shift_mac": {
+    "message": "Shift ⇧"
   },
   "mouse_hover_delay_label": {
     "message": "Hover Delay"

--- a/src/_locales/fa/messages.json
+++ b/src/_locales/fa/messages.json
@@ -474,13 +474,22 @@
     "message": "فقط مکث موس"
   },
   "mouse_hover_trigger_ctrl": {
-    "message": "Ctrl + مکث موس"
+    "message": "Ctrl"
   },
   "mouse_hover_trigger_alt": {
-    "message": "Alt + مکث موس"
+    "message": "Alt"
   },
   "mouse_hover_trigger_shift": {
-    "message": "Shift + مکث موس"
+    "message": "Shift"
+  },
+  "mouse_hover_trigger_ctrl_mac": {
+    "message": "فرمان ⌘ / کنترل ⌃"
+  },
+  "mouse_hover_trigger_alt_mac": {
+    "message": "گزینه ⌥"
+  },
+  "mouse_hover_trigger_shift_mac": {
+    "message": "شیفت ⇧"
   },
   "mouse_hover_delay_label": {
     "message": "زمان انتظار"

--- a/src/_locales/fa/messages.json
+++ b/src/_locales/fa/messages.json
@@ -473,17 +473,20 @@
   "mouse_hover_trigger_hover": {
     "message": "فقط مکث موس"
   },
-  "mouse_hover_trigger_ctrl": {
+  "mouse_hover_trigger_primary": {
     "message": "Ctrl"
+  },
+  "mouse_hover_trigger_primary_mac": {
+    "message": "فرمان ⌘"
+  },
+  "mouse_hover_trigger_control": {
+    "message": "کنترل ⌃"
   },
   "mouse_hover_trigger_alt": {
     "message": "Alt"
   },
   "mouse_hover_trigger_shift": {
     "message": "Shift"
-  },
-  "mouse_hover_trigger_ctrl_mac": {
-    "message": "فرمان ⌘ / کنترل ⌃"
   },
   "mouse_hover_trigger_alt_mac": {
     "message": "گزینه ⌥"

--- a/src/_locales/ja/messages.json
+++ b/src/_locales/ja/messages.json
@@ -657,13 +657,22 @@
     "message": "即時（ホバー）"
   },
   "mouse_hover_trigger_ctrl": {
-    "message": "Ctrl + ホバー"
+    "message": "Ctrl"
   },
   "mouse_hover_trigger_alt": {
-    "message": "Alt + ホバー"
+    "message": "Alt"
   },
   "mouse_hover_trigger_shift": {
-    "message": "Shift + ホバー"
+    "message": "Shift"
+  },
+  "mouse_hover_trigger_ctrl_mac": {
+    "message": "コマンド ⌘ / Control ⌃"
+  },
+  "mouse_hover_trigger_alt_mac": {
+    "message": "オプション ⌥"
+  },
+  "mouse_hover_trigger_shift_mac": {
+    "message": "シフト ⇧"
   },
   "mouse_hover_delay_label": {
     "message": "ホバー遅延"

--- a/src/_locales/ja/messages.json
+++ b/src/_locales/ja/messages.json
@@ -656,17 +656,20 @@
   "mouse_hover_trigger_hover": {
     "message": "即時（ホバー）"
   },
-  "mouse_hover_trigger_ctrl": {
+  "mouse_hover_trigger_primary": {
     "message": "Ctrl"
+  },
+  "mouse_hover_trigger_primary_mac": {
+    "message": "コマンド ⌘"
+  },
+  "mouse_hover_trigger_control": {
+    "message": "Control ⌃"
   },
   "mouse_hover_trigger_alt": {
     "message": "Alt"
   },
   "mouse_hover_trigger_shift": {
     "message": "Shift"
-  },
-  "mouse_hover_trigger_ctrl_mac": {
-    "message": "コマンド ⌘ / Control ⌃"
   },
   "mouse_hover_trigger_alt_mac": {
     "message": "オプション ⌥"

--- a/src/apps/options/tabs/ActivationTab.vue
+++ b/src/apps/options/tabs/ActivationTab.vue
@@ -842,6 +842,7 @@ import { LOG_COMPONENTS } from '@/shared/logging/logConstants.js'
 import { TranslationMode, SelectionTranslationMode, CONFIG } from '@/shared/config/config.js'
 import { MOBILE_CONSTANTS } from '@/shared/constants/mobile.js'
 import { useHighlightManager } from '../composables/useHighlightManager.js'
+import { detectOS, OS_PLATFORMS } from '@/utils/browser/compatibility.js'
 
 // Components
 import BaseCheckbox from '@/components/base/BaseCheckbox.vue'
@@ -1019,6 +1020,7 @@ const mouseHoverAutoClose = createSetting('MOUSE_HOVER_AUTO_CLOSE', 'mouseleave'
 const mouseHoverTimerDuration = createSetting('MOUSE_HOVER_TIMER_DURATION', 3000)
 const mouseHoverShowBorder = createSetting('MOUSE_HOVER_SHOW_CONTAINER_BORDER', true)
 const showMouseHoverInFab = createSetting('SHOW_MOUSE_HOVER_IN_FAB', true)
+const isMacOS = detectOS() === OS_PLATFORMS.MAC
 
 const mouseHoverScopeOptions = computed(() => [
   { value: 'word', label: t('mouse_hover_scope_word') || 'Word' },
@@ -1028,9 +1030,20 @@ const mouseHoverScopeOptions = computed(() => [
 
 const mouseHoverTriggerOptions = computed(() => [
   { value: 'hover', label: t('mouse_hover_trigger_hover') || 'Immediate (Hover)' },
-  { value: 'ctrl', label: t('mouse_hover_trigger_ctrl') || 'Ctrl + Hover' },
-  { value: 'alt', label: t('mouse_hover_trigger_alt') || 'Alt + Hover' },
-  { value: 'shift', label: t('mouse_hover_trigger_shift') || 'Shift + Hover' }
+  {
+    value: 'ctrl',
+    label: isMacOS
+      ? t('mouse_hover_trigger_ctrl_mac') || 'Command ⌘ / Control ⌃'
+      : t('mouse_hover_trigger_ctrl') || 'Ctrl'
+  },
+  {
+    value: 'alt',
+    label: isMacOS ? t('mouse_hover_trigger_alt_mac') || 'Option ⌥' : t('mouse_hover_trigger_alt') || 'Alt'
+  },
+  {
+    value: 'shift',
+    label: isMacOS ? t('mouse_hover_trigger_shift_mac') || 'Shift ⇧' : t('mouse_hover_trigger_shift') || 'Shift'
+  }
 ])
 
 const mouseHoverAutoCloseOptions = computed(() => [

--- a/src/apps/options/tabs/ActivationTab.vue
+++ b/src/apps/options/tabs/ActivationTab.vue
@@ -541,7 +541,7 @@
             <div class="setting-control-group">
               <BaseSelect
                 id="MOUSE_HOVER_TRIGGER"
-                v-model="mouseHoverTrigger"
+                v-model="mouseHoverTriggerUi"
                 :options="mouseHoverTriggerOptions"
                 :disabled="!extensionEnabled || !mouseHoverEnabled"
                 class="compact-select"
@@ -1014,13 +1014,21 @@ const handleKeyDown = (e) => {
 // Mouse on Hover
 const mouseHoverEnabled = createSetting('MOUSE_HOVER_TRANSLATION_ENABLED', false)
 const mouseHoverScope = createSetting('MOUSE_HOVER_SCOPE', 'container')
-const mouseHoverTrigger = createSetting('MOUSE_HOVER_TRIGGER', 'ctrl')
+const mouseHoverTrigger = createSetting('MOUSE_HOVER_TRIGGER', CONFIG.MOUSE_HOVER_TRIGGER)
 const mouseHoverDelay = createSetting('MOUSE_HOVER_DELAY', 500)
 const mouseHoverAutoClose = createSetting('MOUSE_HOVER_AUTO_CLOSE', 'mouseleave')
 const mouseHoverTimerDuration = createSetting('MOUSE_HOVER_TIMER_DURATION', 3000)
 const mouseHoverShowBorder = createSetting('MOUSE_HOVER_SHOW_CONTAINER_BORDER', true)
 const showMouseHoverInFab = createSetting('SHOW_MOUSE_HOVER_IN_FAB', true)
 const isMacOS = detectOS() === OS_PLATFORMS.MAC
+const mouseHoverTriggerUi = computed({
+  get: () => !isMacOS && mouseHoverTrigger.value === 'control'
+    ? 'primary'
+    : mouseHoverTrigger.value,
+  set: (value) => {
+    mouseHoverTrigger.value = value
+  }
+})
 
 const mouseHoverScopeOptions = computed(() => [
   { value: 'word', label: t('mouse_hover_scope_word') || 'Word' },
@@ -1028,23 +1036,25 @@ const mouseHoverScopeOptions = computed(() => [
   { value: 'container', label: t('mouse_hover_scope_container') || 'Container' }
 ])
 
-const mouseHoverTriggerOptions = computed(() => [
-  { value: 'hover', label: t('mouse_hover_trigger_hover') || 'Immediate (Hover)' },
-  {
-    value: 'ctrl',
-    label: isMacOS
-      ? t('mouse_hover_trigger_ctrl_mac') || 'Command ⌘ / Control ⌃'
-      : t('mouse_hover_trigger_ctrl') || 'Ctrl'
-  },
-  {
-    value: 'alt',
-    label: isMacOS ? t('mouse_hover_trigger_alt_mac') || 'Option ⌥' : t('mouse_hover_trigger_alt') || 'Alt'
-  },
-  {
-    value: 'shift',
-    label: isMacOS ? t('mouse_hover_trigger_shift_mac') || 'Shift ⇧' : t('mouse_hover_trigger_shift') || 'Shift'
-  }
-])
+const mouseHoverTriggerOptions = computed(() => {
+  const modifierOptions = isMacOS
+    ? [
+        { value: 'primary', label: t('mouse_hover_trigger_primary_mac') || 'Command ⌘' },
+        { value: 'control', label: t('mouse_hover_trigger_control') || 'Control ⌃' },
+        { value: 'alt', label: t('mouse_hover_trigger_alt_mac') || 'Option ⌥' },
+        { value: 'shift', label: t('mouse_hover_trigger_shift_mac') || 'Shift ⇧' }
+      ]
+    : [
+        { value: 'primary', label: t('mouse_hover_trigger_primary') || 'Ctrl' },
+        { value: 'alt', label: t('mouse_hover_trigger_alt') || 'Alt' },
+        { value: 'shift', label: t('mouse_hover_trigger_shift') || 'Shift' }
+      ]
+
+  return [
+    { value: 'hover', label: t('mouse_hover_trigger_hover') || 'Immediate (Hover)' },
+    ...modifierOptions
+  ]
+})
 
 const mouseHoverAutoCloseOptions = computed(() => [
   { value: 'mouseleave', label: t('mouse_hover_autoclose_mouseleave') || 'On Mouse Leave' },

--- a/src/features/mouse-hover/HoverTranslationManager.js
+++ b/src/features/mouse-hover/HoverTranslationManager.js
@@ -5,7 +5,7 @@ import { HoverTextDetector } from './HoverTextDetector.js';
 import { pageEventBus } from '@/core/PageEventBus.js';
 import { registerTranslation, contentScriptIntegration } from '@/shared/messaging/core/ContentScriptIntegration.js';
 import { MessageActions } from '@/shared/messaging/core/MessageActions.js';
-import { TranslationMode } from '@/shared/config/config.js';
+import { CONFIG, TranslationMode } from '@/shared/config/config.js';
 import { settingsManager } from '@/shared/managers/SettingsManager.js';
 import { MessageContexts, MessageFormat } from '@/shared/messaging/core/MessagingCore.js';
 import { ElementDetectionService } from '@/shared/services/ElementDetectionService.js';
@@ -175,7 +175,7 @@ export class HoverTranslationManager extends ResourceTracker {
       return;
     }
 
-    const trigger = settingsManager.get('MOUSE_HOVER_TRIGGER', 'hover');
+    const trigger = settingsManager.get('MOUSE_HOVER_TRIGGER', CONFIG.MOUSE_HOVER_TRIGGER);
     
     // Modifier modes trigger only from the modifier release lifecycle.
     if (trigger !== 'hover') {
@@ -203,7 +203,7 @@ export class HoverTranslationManager extends ResourceTracker {
    * Handle key down for modifier trigger gesture recognition
    */
   handleKeyDown(event) {
-    const trigger = settingsManager.get('MOUSE_HOVER_TRIGGER', 'hover');
+    const trigger = settingsManager.get('MOUSE_HOVER_TRIGGER', CONFIG.MOUSE_HOVER_TRIGGER);
     if (trigger === 'hover') {
       this.modifierTriggerController.reset();
       return;
@@ -222,7 +222,7 @@ export class HoverTranslationManager extends ResourceTracker {
    * Handle modifier release and schedule one hover check for valid gestures.
    */
   handleKeyUp(event) {
-    const trigger = settingsManager.get('MOUSE_HOVER_TRIGGER', 'hover');
+    const trigger = settingsManager.get('MOUSE_HOVER_TRIGGER', CONFIG.MOUSE_HOVER_TRIGGER);
     if (trigger === 'hover') {
       this.modifierTriggerController.reset();
       return;

--- a/src/features/mouse-hover/HoverTranslationManager.js
+++ b/src/features/mouse-hover/HoverTranslationManager.js
@@ -14,6 +14,7 @@ import { isEditable } from '@/core/helpers.js';
 import { ErrorTypes } from '@/shared/error-management/ErrorTypes.js';
 import { mapCanonicalTranslationError } from '@/shared/error-management/PublicTranslationErrorPolicy.js';
 import { createLegacyDisplayError } from '@/shared/error-management/PublicTranslationErrorAdapter.js';
+import { ModifierTriggerController } from './ModifierTriggerController.js';
 
 // Import CSS as inline string
 import hoverStyles from './HoverHighlight.scss?inline';
@@ -52,11 +53,17 @@ export class HoverTranslationManager extends ResourceTracker {
     this.currentRect = null; // Rectangle Cache for performance optimization
     this.borderedElement = null; // Tracking element with active border
     this.currentMessageId = null; // Tracking active translation request
+    this.modifierTriggerController = new ModifierTriggerController();
     
     // Bind handlers
     this.handleMouseMove = this.handleMouseMove.bind(this);
     this.handleMouseLeave = this.handleMouseLeave.bind(this);
     this.handleKeyDown = this.handleKeyDown.bind(this);
+    this.handleKeyUp = this.handleKeyUp.bind(this);
+    this.handlePointerDown = this.handlePointerDown.bind(this);
+    this.handleWheel = this.handleWheel.bind(this);
+    this.handleWindowBlur = this.handleWindowBlur.bind(this);
+    this.handleVisibilityChange = this.handleVisibilityChange.bind(this);
   }
 
   /**
@@ -75,7 +82,13 @@ export class HoverTranslationManager extends ResourceTracker {
       // Use ResourceTracker to manage event listeners
       this.addEventListener(document, 'mousemove', this.handleMouseMove, { passive: true });
       this.addEventListener(document, 'keydown', this.handleKeyDown, { passive: true });
+      this.addEventListener(document, 'keyup', this.handleKeyUp, { passive: true });
+      this.addEventListener(document, 'mousedown', this.handlePointerDown, { passive: true });
+      this.addEventListener(document, 'pointerdown', this.handlePointerDown, { passive: true });
+      this.addEventListener(document, 'wheel', this.handleWheel, { passive: true });
       this.addEventListener(document, 'mouseleave', this.handleMouseLeave, { passive: true });
+      this.addEventListener(window, 'blur', this.handleWindowBlur, { passive: true });
+      this.addEventListener(document, 'visibilitychange', this.handleVisibilityChange, { passive: true });
       
       this.isActive = true;
       logger.info('Hover translation manager activated and listening');
@@ -99,7 +112,10 @@ export class HoverTranslationManager extends ResourceTracker {
    * Deactivate the hover translation feature
    */
   async deactivate() {
-    if (!this.isActive) return true;
+    if (!this.isActive) {
+      this.modifierTriggerController.reset();
+      return true;
+    }
 
     this.cleanup(); // Clean up all listeners and timers
     this.isActive = false;
@@ -116,7 +132,7 @@ export class HoverTranslationManager extends ResourceTracker {
    * Handle mouse move events with debouncing logic
    */
   handleMouseMove(event) {
-    // Store last mouse event for keydown trigger
+    // Store last mouse event for modifier release trigger
     this.lastMouseEvent = event;
 
     // Check if mouse actually moved significantly to avoid noise
@@ -153,6 +169,7 @@ export class HoverTranslationManager extends ResourceTracker {
 
     // Skip if mouse is over editable elements (inputs, textareas, etc.)
     if (isEditable(event.target)) {
+      this.modifierTriggerController.reset();
       this._cancelPendingHover();
       this._handleMouseOut();
       return;
@@ -160,8 +177,8 @@ export class HoverTranslationManager extends ResourceTracker {
 
     const trigger = settingsManager.get('MOUSE_HOVER_TRIGGER', 'hover');
     
-    // Check modifier key if required
-    if (trigger !== 'hover' && !this._isModifierPressed(event, trigger)) {
+    // Modifier modes trigger only from the modifier release lifecycle.
+    if (trigger !== 'hover') {
       this._cancelPendingHover();
       
       // If we don't have a tooltip, we can stop here. 
@@ -183,29 +200,78 @@ export class HoverTranslationManager extends ResourceTracker {
   }
 
   /**
-   * Handle key down for modifier triggers
+   * Handle key down for modifier trigger gesture recognition
    */
   handleKeyDown(event) {
     const trigger = settingsManager.get('MOUSE_HOVER_TRIGGER', 'hover');
-    if (trigger === 'hover') return;
-
-    // Ignore modifier keys if user is typing in a field (focused on an editable element)
-    if (isEditable(document.activeElement)) {
+    if (trigger === 'hover') {
+      this.modifierTriggerController.reset();
       return;
     }
 
-    if (this._isModifierPressed(event, trigger)) {
-      // If we have a stored mouse event and we're over an element
-      if (this.lastMouseEvent && this.lastMouseEvent.target) {
-        logger.debug(`Modifier key ${trigger} pressed while mouse over element, triggering immediate hover check`);
-        this._cancelPendingHover();
-        
-        // Trigger check with a very small safety delay
-        this.hoverTimer = this.setTimeout(() => {
-          this._processHover(this.lastMouseEvent);
-        }, MODIFIER_TRIGGER_DELAY);
-      }
+    // Ignore modifier keys if user is typing in a field (focused on an editable element)
+    if (isEditable(document.activeElement)) {
+      this.modifierTriggerController.reset();
+      return;
     }
+
+    this.modifierTriggerController.handleKeyDown(event, trigger);
+  }
+
+  /**
+   * Handle modifier release and schedule one hover check for valid gestures.
+   */
+  handleKeyUp(event) {
+    const trigger = settingsManager.get('MOUSE_HOVER_TRIGGER', 'hover');
+    if (trigger === 'hover') {
+      this.modifierTriggerController.reset();
+      return;
+    }
+
+    if (isEditable(document.activeElement)) {
+      this.modifierTriggerController.reset();
+      return;
+    }
+
+    if (!this.modifierTriggerController.handleKeyUp(event, trigger)) return;
+
+    const mouseEvent = this.lastMouseEvent;
+    if (!mouseEvent?.target || isEditable(mouseEvent.target)) return;
+    if (ElementDetectionService.getInstance().isUIElement(mouseEvent.target)) return;
+
+    logger.debug(`Modifier key ${trigger} released while mouse over element, scheduling hover check`);
+    this._cancelPendingHover();
+    this.hoverTimer = this.setTimeout(() => {
+      this._processHover(mouseEvent);
+    }, MODIFIER_TRIGGER_DELAY);
+  }
+
+  /**
+   * Invalidate modifier gesture when pointer interaction begins.
+   */
+  handlePointerDown() {
+    this.modifierTriggerController.invalidate();
+  }
+
+  /**
+   * Invalidate modifier gesture when wheel interaction begins.
+   */
+  handleWheel() {
+    this.modifierTriggerController.invalidate();
+  }
+
+  /**
+   * Clear modifier gesture when page focus is lost.
+   */
+  handleWindowBlur() {
+    this.modifierTriggerController.reset();
+  }
+
+  /**
+   * Clear modifier gesture on document visibility changes.
+   */
+  handleVisibilityChange() {
+    this.modifierTriggerController.reset();
   }
 
   /**
@@ -507,22 +573,10 @@ export class HoverTranslationManager extends ResourceTracker {
   }
 
   /**
-   * Check if the required modifier key is pressed
-   * @private
-   */
-  _isModifierPressed(event, modifier) {
-    switch (modifier) {
-      case 'ctrl': return event.ctrlKey || event.metaKey;
-      case 'alt': return event.altKey;
-      case 'shift': return event.shiftKey;
-      default: return true;
-    }
-  }
-
-  /**
    * Clean up resources
    */
   cleanup() {
+    this.modifierTriggerController.reset();
     this._cancelPendingHover();
     super.cleanup();
   }

--- a/src/features/mouse-hover/HoverTranslationManager.test.js
+++ b/src/features/mouse-hover/HoverTranslationManager.test.js
@@ -66,6 +66,16 @@ vi.mock('@/core/helpers.js', () => ({
 
 import { isEditable } from '@/core/helpers.js';
 
+const keyEvent = (key, options = {}) => ({
+  key,
+  ctrlKey: false,
+  altKey: false,
+  shiftKey: false,
+  metaKey: false,
+  repeat: false,
+  ...options
+});
+
 describe('HoverTranslationManager', () => {
   let manager;
 
@@ -115,8 +125,13 @@ describe('HoverTranslationManager', () => {
   describe('handleMouseMove', () => {
     it('should debounce detection', async () => {
       await manager.activate();
+      settingsManager.get.mockImplementation((key, def) => {
+        if (key === 'MOUSE_HOVER_TRIGGER') return 'hover';
+        if (key === 'MOUSE_HOVER_DELAY') return 300;
+        return def;
+      });
       
-      const event = { clientX: 10, clientY: 10, target: document.body, ctrlKey: true };
+      const event = { clientX: 10, clientY: 10, target: document.body };
       manager.handleMouseMove(event);
 
       expect(HoverTextDetector.detect).not.toHaveBeenCalled();
@@ -140,13 +155,18 @@ describe('HoverTranslationManager', () => {
 
     it('should cancel pending hover if mouse moves away before delay', async () => {
       await manager.activate();
+      settingsManager.get.mockImplementation((key, def) => {
+        if (key === 'MOUSE_HOVER_TRIGGER') return 'hover';
+        if (key === 'MOUSE_HOVER_DELAY') return 300;
+        return def;
+      });
       
       // First move
-      manager.handleMouseMove({ clientX: 10, clientY: 10, target: document.body, ctrlKey: true });
+      manager.handleMouseMove({ clientX: 10, clientY: 10, target: document.body });
       vi.advanceTimersByTime(200);
       
       // Second move (cancels first)
-      manager.handleMouseMove({ clientX: 100, clientY: 100, target: document.body, ctrlKey: true });
+      manager.handleMouseMove({ clientX: 100, clientY: 100, target: document.body });
       
       vi.advanceTimersByTime(200); // Only 200ms since 2nd move
       expect(HoverTextDetector.detect).not.toHaveBeenCalled();
@@ -155,21 +175,35 @@ describe('HoverTranslationManager', () => {
       expect(HoverTextDetector.detect).toHaveBeenCalledTimes(1);
     });
 
-    it('should respect modifier key settings', async () => {
+    it('should not schedule translation from mousemove in modifier mode', async () => {
       await manager.activate();
-      settingsManager.get.mockImplementation((key, def) => {
-        if (key === 'MOUSE_HOVER_TRIGGER') return 'ctrl';
-        return def;
-      });
-
-      // Move without Ctrl
-      manager.handleMouseMove({ clientX: 10, clientY: 10, target: document.body, ctrlKey: false });
-      vi.advanceTimersByTime(600);
-      expect(HoverTextDetector.detect).not.toHaveBeenCalled();
-
-      // Move with Ctrl (different position to avoid dist < 2)
+      manager.handleMouseMove({ clientX: 10, clientY: 10, target: document.body, ctrlKey: true });
       manager.handleMouseMove({ clientX: 50, clientY: 50, target: document.body, ctrlKey: true });
       vi.advanceTimersByTime(600);
+
+      expect(HoverTextDetector.detect).not.toHaveBeenCalled();
+    });
+
+    it('keeps latest mouse event for modifier release', async () => {
+      await manager.activate();
+      manager.handleMouseMove({ clientX: 10, clientY: 10, target: document.body });
+      manager.handleKeyDown(keyEvent('Control', { ctrlKey: true }));
+      manager.handleMouseMove({ clientX: 50, clientY: 50, target: document.body, ctrlKey: true });
+      manager.handleKeyUp(keyEvent('Control'));
+
+      vi.advanceTimersByTime(50);
+
+      expect(HoverTextDetector.detect).toHaveBeenCalledWith(50, 50, 'sentence');
+    });
+
+    it('does not invalidate pending modifier gesture on mouse movement', async () => {
+      await manager.activate();
+      manager.handleKeyDown(keyEvent('Control', { ctrlKey: true }));
+      manager.handleMouseMove({ clientX: 20, clientY: 20, target: document.body, ctrlKey: true });
+      manager.handleKeyUp(keyEvent('Control'));
+
+      vi.advanceTimersByTime(50);
+
       expect(HoverTextDetector.detect).toHaveBeenCalled();
     });
 
@@ -186,35 +220,169 @@ describe('HoverTranslationManager', () => {
   });
 
   describe('handleKeyDown', () => {
-    it('should trigger translation immediately if modifier is pressed', async () => {
+    it('should not trigger translation before modifier release', async () => {
       await manager.activate();
-      settingsManager.get.mockImplementation((key, def) => {
-        if (key === 'MOUSE_HOVER_TRIGGER') return 'ctrl';
-        return def;
-      });
 
       manager.lastMouseEvent = { clientX: 10, clientY: 10, target: document.body };
       
-      manager.handleKeyDown({ ctrlKey: true });
-      
-      vi.advanceTimersByTime(60); // Modifier trigger has 50ms delay
-      expect(HoverTextDetector.detect).toHaveBeenCalled();
-    });
-
-    it('should NOT trigger translation if active element is editable', async () => {
-      await manager.activate();
-      settingsManager.get.mockImplementation((key, def) => {
-        if (key === 'MOUSE_HOVER_TRIGGER') return 'ctrl';
-        return def;
-      });
-      
-      isEditable.mockReturnValue(true);
-      manager.lastMouseEvent = { clientX: 10, clientY: 10, target: document.body };
-      
-      manager.handleKeyDown({ ctrlKey: true });
+      manager.handleKeyDown(keyEvent('Control', { ctrlKey: true }));
       
       vi.advanceTimersByTime(60);
       expect(HoverTextDetector.detect).not.toHaveBeenCalled();
+    });
+
+    it('should trigger exactly once on standalone modifier release', async () => {
+      await manager.activate();
+      manager.lastMouseEvent = { clientX: 10, clientY: 10, target: document.body };
+
+      manager.handleKeyDown(keyEvent('Control', { ctrlKey: true }));
+      manager.handleKeyUp(keyEvent('Control'));
+      manager.handleKeyUp(keyEvent('Control'));
+
+      vi.advanceTimersByTime(50);
+      expect(HoverTextDetector.detect).toHaveBeenCalledTimes(1);
+    });
+
+    it.each([
+      ['A', 'ctrl'],
+      ['C', 'ctrl'],
+      ['A', 'shift']
+    ])('should not translate %s shortcut with %s trigger', async (key, trigger) => {
+      await manager.activate();
+      settingsManager.get.mockImplementation((key, def) => {
+        if (key === 'MOUSE_HOVER_TRIGGER') return trigger;
+        return def;
+      });
+
+      manager.lastMouseEvent = { clientX: 10, clientY: 10, target: document.body };
+
+      const modifier = trigger === 'ctrl' ? 'Control' : 'Shift';
+      manager.handleKeyDown(keyEvent(modifier, {
+        ctrlKey: trigger === 'ctrl',
+        shiftKey: trigger === 'shift'
+      }));
+      manager.handleKeyDown(keyEvent(key, {
+        ctrlKey: trigger === 'ctrl',
+        shiftKey: trigger === 'shift'
+      }));
+      manager.handleKeyUp(keyEvent(modifier));
+
+      vi.advanceTimersByTime(60);
+      expect(HoverTextDetector.detect).not.toHaveBeenCalled();
+    });
+
+    it('should not translate Ctrl+Shift', async () => {
+      await manager.activate();
+      manager.lastMouseEvent = { clientX: 10, clientY: 10, target: document.body };
+
+      manager.handleKeyDown(keyEvent('Control', { ctrlKey: true }));
+      manager.handleKeyDown(keyEvent('Shift', { ctrlKey: true, shiftKey: true }));
+      manager.handleKeyUp(keyEvent('Control'));
+
+      vi.advanceTimersByTime(60);
+      expect(HoverTextDetector.detect).not.toHaveBeenCalled();
+    });
+
+    it('should translate standalone Alt release', async () => {
+      await manager.activate();
+      settingsManager.get.mockImplementation((key, def) => {
+        if (key === 'MOUSE_HOVER_TRIGGER') return 'alt';
+        return def;
+      });
+      manager.lastMouseEvent = { clientX: 10, clientY: 10, target: document.body };
+
+      manager.handleKeyDown(keyEvent('Alt', { altKey: true }));
+      manager.handleKeyUp(keyEvent('Alt'));
+      vi.advanceTimersByTime(50);
+
+      expect(HoverTextDetector.detect).toHaveBeenCalledTimes(1);
+    });
+
+    it('should ignore modifier auto-repeat', async () => {
+      await manager.activate();
+      manager.lastMouseEvent = { clientX: 10, clientY: 10, target: document.body };
+
+      manager.handleKeyDown(keyEvent('Control', { ctrlKey: true }));
+      manager.handleKeyDown(keyEvent('Control', { ctrlKey: true, repeat: true }));
+      manager.handleKeyUp(keyEvent('Control'));
+      manager.handleKeyUp(keyEvent('Control'));
+      vi.advanceTimersByTime(50);
+
+      expect(HoverTextDetector.detect).toHaveBeenCalledTimes(1);
+    });
+
+    it('should not translate while editable target is focused', async () => {
+      await manager.activate();
+      isEditable.mockReturnValue(true);
+      manager.lastMouseEvent = { clientX: 10, clientY: 10, target: document.body };
+
+      manager.handleKeyDown(keyEvent('Control', { ctrlKey: true }));
+      manager.handleKeyUp(keyEvent('Control'));
+      vi.advanceTimersByTime(50);
+
+      expect(HoverTextDetector.detect).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('modifier gesture lifecycle', () => {
+    beforeEach(async () => {
+      await manager.activate();
+      manager.lastMouseEvent = { clientX: 10, clientY: 10, target: document.body };
+    });
+
+    it.each([
+      ['pointer', () => manager.handlePointerDown({})],
+      ['wheel', () => manager.handleWheel({})]
+    ])('cancels pending gesture on %s interaction', async (_name, interact) => {
+      manager.handleKeyDown(keyEvent('Control', { ctrlKey: true }));
+      interact();
+      manager.handleKeyUp(keyEvent('Control'));
+      vi.advanceTimersByTime(50);
+
+      expect(HoverTextDetector.detect).not.toHaveBeenCalled();
+    });
+
+    it('cancels pending gesture on window blur', async () => {
+      manager.handleKeyDown(keyEvent('Control', { ctrlKey: true }));
+      manager.handleWindowBlur();
+      manager.handleKeyUp(keyEvent('Control'));
+      vi.advanceTimersByTime(50);
+
+      expect(HoverTextDetector.detect).not.toHaveBeenCalled();
+    });
+
+    it('cancels pending gesture when document becomes hidden', async () => {
+      const hidden = Object.getOwnPropertyDescriptor(document, 'hidden');
+      Object.defineProperty(document, 'hidden', { configurable: true, value: true });
+      try {
+        manager.handleKeyDown(keyEvent('Control', { ctrlKey: true }));
+        manager.handleVisibilityChange();
+        manager.handleKeyUp(keyEvent('Control'));
+        vi.advanceTimersByTime(50);
+
+        expect(HoverTextDetector.detect).not.toHaveBeenCalled();
+      } finally {
+        if (hidden) {
+          Object.defineProperty(document, 'hidden', hidden);
+        } else {
+          delete document.hidden;
+        }
+      }
+    });
+
+    it('clears pending gesture on deactivation', async () => {
+      manager.handleKeyDown(keyEvent('Control', { ctrlKey: true }));
+      await manager.deactivate();
+
+      expect(manager.modifierTriggerController.state).toBe('IDLE');
+    });
+
+    it('preserves ctrl Meta compatibility', async () => {
+      manager.handleKeyDown(keyEvent('Meta', { metaKey: true }));
+      manager.handleKeyUp(keyEvent('Meta'));
+      vi.advanceTimersByTime(50);
+
+      expect(HoverTextDetector.detect).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/src/features/mouse-hover/HoverTranslationManager.test.js
+++ b/src/features/mouse-hover/HoverTranslationManager.test.js
@@ -90,7 +90,7 @@ describe('HoverTranslationManager', () => {
     // Set default setting mocks
     settingsManager.get.mockImplementation((key, def) => {
       if (key === 'MOUSE_HOVER_AUTO_CLOSE') return 'mouseleave';
-      if (key === 'MOUSE_HOVER_TRIGGER') return 'ctrl';
+      if (key === 'MOUSE_HOVER_TRIGGER') return 'primary';
       if (key === 'MOUSE_HOVER_DELAY') return 300;
       return def;
     });
@@ -231,8 +231,12 @@ describe('HoverTranslationManager', () => {
       expect(HoverTextDetector.detect).not.toHaveBeenCalled();
     });
 
-    it('should trigger exactly once on standalone modifier release', async () => {
+    it.each(['primary', 'control'])('should trigger exactly once on standalone %s release', async (trigger) => {
       await manager.activate();
+      settingsManager.get.mockImplementation((key, def) => {
+        if (key === 'MOUSE_HOVER_TRIGGER') return trigger;
+        return def;
+      });
       manager.lastMouseEvent = { clientX: 10, clientY: 10, target: document.body };
 
       manager.handleKeyDown(keyEvent('Control', { ctrlKey: true }));
@@ -244,8 +248,8 @@ describe('HoverTranslationManager', () => {
     });
 
     it.each([
-      ['A', 'ctrl'],
-      ['C', 'ctrl'],
+      ['A', 'primary'],
+      ['C', 'primary'],
       ['A', 'shift']
     ])('should not translate %s shortcut with %s trigger', async (key, trigger) => {
       await manager.activate();
@@ -256,13 +260,13 @@ describe('HoverTranslationManager', () => {
 
       manager.lastMouseEvent = { clientX: 10, clientY: 10, target: document.body };
 
-      const modifier = trigger === 'ctrl' ? 'Control' : 'Shift';
+      const modifier = trigger === 'primary' ? 'Control' : 'Shift';
       manager.handleKeyDown(keyEvent(modifier, {
-        ctrlKey: trigger === 'ctrl',
+        ctrlKey: trigger === 'primary',
         shiftKey: trigger === 'shift'
       }));
       manager.handleKeyDown(keyEvent(key, {
-        ctrlKey: trigger === 'ctrl',
+        ctrlKey: trigger === 'primary',
         shiftKey: trigger === 'shift'
       }));
       manager.handleKeyUp(keyEvent(modifier));
@@ -377,12 +381,17 @@ describe('HoverTranslationManager', () => {
       expect(manager.modifierTriggerController.state).toBe('IDLE');
     });
 
-    it('preserves ctrl Meta compatibility', async () => {
+    it('does not trigger explicit Control mode from Meta', async () => {
+      settingsManager.get.mockImplementation((key, def) => {
+        if (key === 'MOUSE_HOVER_TRIGGER') return 'control';
+        return def;
+      });
+
       manager.handleKeyDown(keyEvent('Meta', { metaKey: true }));
       manager.handleKeyUp(keyEvent('Meta'));
       vi.advanceTimersByTime(50);
 
-      expect(HoverTextDetector.detect).toHaveBeenCalledTimes(1);
+      expect(HoverTextDetector.detect).not.toHaveBeenCalled();
     });
   });
 

--- a/src/features/mouse-hover/ModifierTriggerController.js
+++ b/src/features/mouse-hover/ModifierTriggerController.js
@@ -1,8 +1,24 @@
-const MODIFIER_KEYS = Object.freeze({
-  ctrl: new Set(['Control', 'Meta']),
-  alt: new Set(['Alt']),
-  shift: new Set(['Shift'])
+import { detectOS, OS_PLATFORMS } from '@/utils/browser/compatibility.js';
+
+const FIXED_TRIGGER_KEYS = Object.freeze({
+  control: 'Control',
+  alt: 'Alt',
+  shift: 'Shift'
 });
+
+/**
+ * Resolve configured Mouse Hover trigger values to physical keyboard identities.
+ * @param {string} trigger
+ * @param {string} platform
+ * @returns {Set<string>}
+ */
+export function getTriggerKeys(trigger, platform = detectOS()) {
+  const key = trigger === 'primary'
+    ? platform === OS_PLATFORMS.MAC ? 'Meta' : 'Control'
+    : Object.hasOwn(FIXED_TRIGGER_KEYS, trigger) ? FIXED_TRIGGER_KEYS[trigger] : null;
+
+  return key ? new Set([key]) : new Set();
+}
 
 export const ModifierTriggerState = Object.freeze({
   IDLE: 'IDLE',
@@ -15,12 +31,13 @@ export const ModifierTriggerState = Object.freeze({
  * @private
  */
 export class ModifierTriggerController {
-  constructor() {
+  constructor(platform = detectOS()) {
     // Standalone release only; hold and double-tap require separate intent rules.
     this.state = ModifierTriggerState.IDLE;
     this.trigger = null;
     this.triggerKey = null;
     this.pressedKeys = new Set();
+    this.platform = platform;
   }
 
   /**
@@ -29,7 +46,8 @@ export class ModifierTriggerController {
    * @param {string} trigger
    */
   handleKeyDown(event, trigger) {
-    if (!this._isSupportedTrigger(trigger)) {
+    const triggerKeys = this._getTriggerKeys(trigger);
+    if (triggerKeys.size === 0) {
       this.reset();
       return;
     }
@@ -44,13 +62,13 @@ export class ModifierTriggerController {
       return;
     }
 
-    const isTriggerKey = this._isTriggerKey(key, trigger);
+    const isTriggerKey = triggerKeys.has(key);
 
     // Repeated modifier keydown must not start or duplicate a gesture.
     if (isTriggerKey && event.repeat) return;
 
     if (this.state === ModifierTriggerState.IDLE) {
-      if (isTriggerKey && this.pressedKeys.size === 0 && this._isStandaloneModifier(event, trigger)) {
+      if (isTriggerKey && this.pressedKeys.size === 0 && this._isStandaloneModifier(event, key)) {
         this.state = ModifierTriggerState.PENDING;
         this.trigger = trigger;
         this.triggerKey = key;
@@ -75,7 +93,7 @@ export class ModifierTriggerController {
     const key = event?.key;
     if (key) this.pressedKeys.delete(key);
 
-    if (!this._isSupportedTrigger(trigger) || (this.trigger && this.trigger !== trigger)) {
+    if (this._getTriggerKeys(trigger).size === 0 || (this.trigger && this.trigger !== trigger)) {
       this.reset();
       return false;
     }
@@ -108,23 +126,19 @@ export class ModifierTriggerController {
     this.pressedKeys.clear();
   }
 
-  _isSupportedTrigger(trigger) {
-    return Object.hasOwn(MODIFIER_KEYS, trigger);
+  _getTriggerKeys(trigger) {
+    return getTriggerKeys(trigger, this.platform);
   }
 
-  _isTriggerKey(key, trigger) {
-    return MODIFIER_KEYS[trigger]?.has(key) === true;
-  }
-
-  _isStandaloneModifier(event, trigger) {
-    switch (trigger) {
-      case 'ctrl':
-        return !event.altKey
-          && !event.shiftKey
-          && (event.key === 'Control' ? !event.metaKey : !event.ctrlKey);
-      case 'alt':
+  _isStandaloneModifier(event, triggerKey) {
+    switch (triggerKey) {
+      case 'Control':
+        return !event.altKey && !event.shiftKey && !event.metaKey;
+      case 'Meta':
+        return !event.ctrlKey && !event.altKey && !event.shiftKey;
+      case 'Alt':
         return !event.ctrlKey && !event.shiftKey && !event.metaKey;
-      case 'shift':
+      case 'Shift':
         return !event.ctrlKey && !event.altKey && !event.metaKey;
       default:
         return false;

--- a/src/features/mouse-hover/ModifierTriggerController.js
+++ b/src/features/mouse-hover/ModifierTriggerController.js
@@ -1,0 +1,133 @@
+const MODIFIER_KEYS = Object.freeze({
+  ctrl: new Set(['Control', 'Meta']),
+  alt: new Set(['Alt']),
+  shift: new Set(['Shift'])
+});
+
+export const ModifierTriggerState = Object.freeze({
+  IDLE: 'IDLE',
+  PENDING: 'PENDING',
+  INVALID: 'INVALID'
+});
+
+/**
+ * Recognizes standalone modifier press/release gestures.
+ * @private
+ */
+export class ModifierTriggerController {
+  constructor() {
+    // Standalone release only; hold and double-tap require separate intent rules.
+    this.state = ModifierTriggerState.IDLE;
+    this.trigger = null;
+    this.triggerKey = null;
+    this.pressedKeys = new Set();
+  }
+
+  /**
+   * Record keyboard input without handling translation behavior.
+   * @param {KeyboardEvent|Object} event
+   * @param {string} trigger
+   */
+  handleKeyDown(event, trigger) {
+    if (!this._isSupportedTrigger(trigger)) {
+      this.reset();
+      return;
+    }
+
+    if (this.trigger && this.trigger !== trigger) {
+      this.reset();
+    }
+
+    const key = event?.key;
+    if (!key) {
+      this.invalidate();
+      return;
+    }
+
+    const isTriggerKey = this._isTriggerKey(key, trigger);
+
+    // Repeated modifier keydown must not start or duplicate a gesture.
+    if (isTriggerKey && event.repeat) return;
+
+    if (this.state === ModifierTriggerState.IDLE) {
+      if (isTriggerKey && this.pressedKeys.size === 0 && this._isStandaloneModifier(event, trigger)) {
+        this.state = ModifierTriggerState.PENDING;
+        this.trigger = trigger;
+        this.triggerKey = key;
+      }
+    } else if (
+      this.state === ModifierTriggerState.PENDING
+      && (!isTriggerKey || key !== this.triggerKey)
+    ) {
+      this.state = ModifierTriggerState.INVALID;
+    }
+
+    this.pressedKeys.add(key);
+  }
+
+  /**
+   * Complete valid standalone gestures on matching modifier release.
+   * @param {KeyboardEvent|Object} event
+   * @param {string} trigger
+   * @returns {boolean} Whether release should trigger translation
+   */
+  handleKeyUp(event, trigger) {
+    const key = event?.key;
+    if (key) this.pressedKeys.delete(key);
+
+    if (!this._isSupportedTrigger(trigger) || (this.trigger && this.trigger !== trigger)) {
+      this.reset();
+      return false;
+    }
+
+    if (this.state === ModifierTriggerState.IDLE || key !== this.triggerKey) {
+      return false;
+    }
+
+    const shouldTrigger = this.state === ModifierTriggerState.PENDING;
+    this.reset();
+    return shouldTrigger;
+  }
+
+  /**
+   * Invalidate current gesture without treating interaction as a new gesture.
+   */
+  invalidate() {
+    if (this.state === ModifierTriggerState.PENDING) {
+      this.state = ModifierTriggerState.INVALID;
+    }
+  }
+
+  /**
+   * Reset gesture and tracked keyboard state.
+   */
+  reset() {
+    this.state = ModifierTriggerState.IDLE;
+    this.trigger = null;
+    this.triggerKey = null;
+    this.pressedKeys.clear();
+  }
+
+  _isSupportedTrigger(trigger) {
+    return Object.hasOwn(MODIFIER_KEYS, trigger);
+  }
+
+  _isTriggerKey(key, trigger) {
+    return MODIFIER_KEYS[trigger]?.has(key) === true;
+  }
+
+  _isStandaloneModifier(event, trigger) {
+    switch (trigger) {
+      case 'ctrl':
+        return !event.altKey
+          && !event.shiftKey
+          && (event.key === 'Control' ? !event.metaKey : !event.ctrlKey);
+      case 'alt':
+        return !event.ctrlKey && !event.shiftKey && !event.metaKey;
+      case 'shift':
+        return !event.ctrlKey && !event.altKey && !event.metaKey;
+      default:
+        return false;
+    }
+  }
+}

--- a/src/features/mouse-hover/ModifierTriggerController.test.js
+++ b/src/features/mouse-hover/ModifierTriggerController.test.js
@@ -1,0 +1,100 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  ModifierTriggerController,
+  ModifierTriggerState
+} from './ModifierTriggerController.js';
+
+const keyEvent = (key, options = {}) => ({
+  key,
+  ctrlKey: false,
+  altKey: false,
+  shiftKey: false,
+  metaKey: false,
+  repeat: false,
+  ...options
+});
+
+describe('ModifierTriggerController', () => {
+  let controller;
+
+  beforeEach(() => {
+    controller = new ModifierTriggerController();
+  });
+
+  it('uses key identity instead of modifier flags', () => {
+    controller.handleKeyDown(keyEvent('A', { ctrlKey: true }), 'ctrl');
+
+    expect(controller.state).toBe(ModifierTriggerState.IDLE);
+  });
+
+  it('moves to pending on standalone Control and triggers on release', () => {
+    controller.handleKeyDown(keyEvent('Control', { ctrlKey: true }), 'ctrl');
+
+    expect(controller.state).toBe(ModifierTriggerState.PENDING);
+    expect(controller.handleKeyUp(keyEvent('Control'), 'ctrl')).toBe(true);
+    expect(controller.state).toBe(ModifierTriggerState.IDLE);
+  });
+
+  it.each(['A', 'C'])('invalidates Ctrl+%s', (key) => {
+    controller.handleKeyDown(keyEvent('Control', { ctrlKey: true }), 'ctrl');
+    controller.handleKeyDown(keyEvent(key, { ctrlKey: true }), 'ctrl');
+
+    expect(controller.state).toBe(ModifierTriggerState.INVALID);
+    expect(controller.handleKeyUp(keyEvent('Control'), 'ctrl')).toBe(false);
+  });
+
+  it('invalidates Shift+A', () => {
+    controller.handleKeyDown(keyEvent('Shift', { shiftKey: true }), 'shift');
+    controller.handleKeyDown(keyEvent('A', { shiftKey: true }), 'shift');
+
+    expect(controller.handleKeyUp(keyEvent('Shift'), 'shift')).toBe(false);
+  });
+
+  it('invalidates Ctrl+Shift regardless of press order', () => {
+    controller.handleKeyDown(keyEvent('Control', { ctrlKey: true }), 'ctrl');
+    controller.handleKeyDown(keyEvent('Shift', { ctrlKey: true, shiftKey: true }), 'ctrl');
+    expect(controller.handleKeyUp(keyEvent('Control'), 'ctrl')).toBe(false);
+
+    controller.reset();
+    controller.handleKeyDown(keyEvent('Shift', { shiftKey: true }), 'ctrl');
+    controller.handleKeyDown(keyEvent('Control', { ctrlKey: true, shiftKey: true }), 'ctrl');
+    expect(controller.state).toBe(ModifierTriggerState.IDLE);
+    expect(controller.handleKeyUp(keyEvent('Control'), 'ctrl')).toBe(false);
+  });
+
+  it('supports standalone Alt and Shift triggers', () => {
+    controller.handleKeyDown(keyEvent('Alt', { altKey: true }), 'alt');
+    expect(controller.handleKeyUp(keyEvent('Alt'), 'alt')).toBe(true);
+
+    controller.handleKeyDown(keyEvent('Shift', { shiftKey: true }), 'shift');
+    expect(controller.handleKeyUp(keyEvent('Shift'), 'shift')).toBe(true);
+  });
+
+  it('ignores repeated modifier keydown', () => {
+    controller.handleKeyDown(keyEvent('Control', { ctrlKey: true }), 'ctrl');
+    controller.handleKeyDown(keyEvent('Control', { ctrlKey: true, repeat: true }), 'ctrl');
+
+    expect(controller.handleKeyUp(keyEvent('Control'), 'ctrl')).toBe(true);
+    expect(controller.handleKeyUp(keyEvent('Control'), 'ctrl')).toBe(false);
+  });
+
+  it('accepts Meta as the ctrl trigger equivalent', () => {
+    controller.handleKeyDown(keyEvent('Meta', { metaKey: true }), 'ctrl');
+
+    expect(controller.handleKeyUp(keyEvent('Meta'), 'ctrl')).toBe(true);
+  });
+
+  it('invalidates pending gesture on interaction and resets explicitly', () => {
+    controller.handleKeyDown(keyEvent('Control', { ctrlKey: true }), 'ctrl');
+    controller.invalidate();
+
+    expect(controller.state).toBe(ModifierTriggerState.INVALID);
+    expect(controller.handleKeyUp(keyEvent('Control'), 'ctrl')).toBe(false);
+
+    controller.handleKeyDown(keyEvent('Control', { ctrlKey: true }), 'ctrl');
+    controller.reset();
+
+    expect(controller.state).toBe(ModifierTriggerState.IDLE);
+    expect(controller.pressedKeys.size).toBe(0);
+  });
+});

--- a/src/features/mouse-hover/ModifierTriggerController.test.js
+++ b/src/features/mouse-hover/ModifierTriggerController.test.js
@@ -1,8 +1,10 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import {
   ModifierTriggerController,
-  ModifierTriggerState
+  ModifierTriggerState,
+  getTriggerKeys
 } from './ModifierTriggerController.js';
+import { OS_PLATFORMS } from '@/utils/browser/compatibility.js';
 
 const keyEvent = (key, options = {}) => ({
   key,
@@ -21,26 +23,48 @@ describe('ModifierTriggerController', () => {
     controller = new ModifierTriggerController();
   });
 
+  it.each([
+    [OS_PLATFORMS.WINDOWS, 'Control'],
+    [OS_PLATFORMS.LINUX, 'Control'],
+    [OS_PLATFORMS.MAC, 'Meta']
+  ])('resolves primary on %s to %s', (platform, expectedKey) => {
+    expect(getTriggerKeys('primary', platform)).toEqual(new Set([expectedKey]));
+  });
+
   it('uses key identity instead of modifier flags', () => {
-    controller.handleKeyDown(keyEvent('A', { ctrlKey: true }), 'ctrl');
+    controller = new ModifierTriggerController(OS_PLATFORMS.WINDOWS);
+    controller.handleKeyDown(keyEvent('A', { ctrlKey: true }), 'primary');
 
     expect(controller.state).toBe(ModifierTriggerState.IDLE);
   });
 
-  it('moves to pending on standalone Control and triggers on release', () => {
+  it('does not accept the legacy ctrl trigger value', () => {
+    controller = new ModifierTriggerController(OS_PLATFORMS.WINDOWS);
     controller.handleKeyDown(keyEvent('Control', { ctrlKey: true }), 'ctrl');
 
-    expect(controller.state).toBe(ModifierTriggerState.PENDING);
-    expect(controller.handleKeyUp(keyEvent('Control'), 'ctrl')).toBe(true);
     expect(controller.state).toBe(ModifierTriggerState.IDLE);
+    expect(controller.handleKeyUp(keyEvent('Control'), 'ctrl')).toBe(false);
   });
+
+  it.each([OS_PLATFORMS.WINDOWS, OS_PLATFORMS.LINUX])(
+    'primary moves to pending on standalone Control and triggers on release on %s',
+    (platform) => {
+      controller = new ModifierTriggerController(platform);
+      controller.handleKeyDown(keyEvent('Control', { ctrlKey: true }), 'primary');
+
+      expect(controller.state).toBe(ModifierTriggerState.PENDING);
+      expect(controller.handleKeyUp(keyEvent('Control'), 'primary')).toBe(true);
+      expect(controller.state).toBe(ModifierTriggerState.IDLE);
+    }
+  );
 
   it.each(['A', 'C'])('invalidates Ctrl+%s', (key) => {
-    controller.handleKeyDown(keyEvent('Control', { ctrlKey: true }), 'ctrl');
-    controller.handleKeyDown(keyEvent(key, { ctrlKey: true }), 'ctrl');
+    controller = new ModifierTriggerController(OS_PLATFORMS.WINDOWS);
+    controller.handleKeyDown(keyEvent('Control', { ctrlKey: true }), 'primary');
+    controller.handleKeyDown(keyEvent(key, { ctrlKey: true }), 'primary');
 
     expect(controller.state).toBe(ModifierTriggerState.INVALID);
-    expect(controller.handleKeyUp(keyEvent('Control'), 'ctrl')).toBe(false);
+    expect(controller.handleKeyUp(keyEvent('Control'), 'primary')).toBe(false);
   });
 
   it('invalidates Shift+A', () => {
@@ -51,15 +75,16 @@ describe('ModifierTriggerController', () => {
   });
 
   it('invalidates Ctrl+Shift regardless of press order', () => {
-    controller.handleKeyDown(keyEvent('Control', { ctrlKey: true }), 'ctrl');
-    controller.handleKeyDown(keyEvent('Shift', { ctrlKey: true, shiftKey: true }), 'ctrl');
-    expect(controller.handleKeyUp(keyEvent('Control'), 'ctrl')).toBe(false);
+    controller = new ModifierTriggerController(OS_PLATFORMS.WINDOWS);
+    controller.handleKeyDown(keyEvent('Control', { ctrlKey: true }), 'primary');
+    controller.handleKeyDown(keyEvent('Shift', { ctrlKey: true, shiftKey: true }), 'primary');
+    expect(controller.handleKeyUp(keyEvent('Control'), 'primary')).toBe(false);
 
     controller.reset();
-    controller.handleKeyDown(keyEvent('Shift', { shiftKey: true }), 'ctrl');
-    controller.handleKeyDown(keyEvent('Control', { ctrlKey: true, shiftKey: true }), 'ctrl');
+    controller.handleKeyDown(keyEvent('Shift', { shiftKey: true }), 'primary');
+    controller.handleKeyDown(keyEvent('Control', { ctrlKey: true, shiftKey: true }), 'primary');
     expect(controller.state).toBe(ModifierTriggerState.IDLE);
-    expect(controller.handleKeyUp(keyEvent('Control'), 'ctrl')).toBe(false);
+    expect(controller.handleKeyUp(keyEvent('Control'), 'primary')).toBe(false);
   });
 
   it('supports standalone Alt and Shift triggers', () => {
@@ -71,27 +96,67 @@ describe('ModifierTriggerController', () => {
   });
 
   it('ignores repeated modifier keydown', () => {
-    controller.handleKeyDown(keyEvent('Control', { ctrlKey: true }), 'ctrl');
-    controller.handleKeyDown(keyEvent('Control', { ctrlKey: true, repeat: true }), 'ctrl');
+    controller = new ModifierTriggerController(OS_PLATFORMS.WINDOWS);
+    controller.handleKeyDown(keyEvent('Control', { ctrlKey: true }), 'primary');
+    controller.handleKeyDown(keyEvent('Control', { ctrlKey: true, repeat: true }), 'primary');
 
-    expect(controller.handleKeyUp(keyEvent('Control'), 'ctrl')).toBe(true);
-    expect(controller.handleKeyUp(keyEvent('Control'), 'ctrl')).toBe(false);
+    expect(controller.handleKeyUp(keyEvent('Control'), 'primary')).toBe(true);
+    expect(controller.handleKeyUp(keyEvent('Control'), 'primary')).toBe(false);
   });
 
-  it('accepts Meta as the ctrl trigger equivalent', () => {
-    controller.handleKeyDown(keyEvent('Meta', { metaKey: true }), 'ctrl');
+  it('primary accepts Meta on macOS and rejects Control', () => {
+    controller = new ModifierTriggerController(OS_PLATFORMS.MAC);
+    controller.handleKeyDown(keyEvent('Meta', { metaKey: true }), 'primary');
 
-    expect(controller.handleKeyUp(keyEvent('Meta'), 'ctrl')).toBe(true);
+    expect(controller.handleKeyUp(keyEvent('Meta'), 'primary')).toBe(true);
+
+    controller.handleKeyDown(keyEvent('Control', { ctrlKey: true }), 'primary');
+    expect(controller.state).toBe(ModifierTriggerState.IDLE);
+    expect(controller.handleKeyUp(keyEvent('Control'), 'primary')).toBe(false);
+  });
+
+  it.each([OS_PLATFORMS.WINDOWS, OS_PLATFORMS.LINUX])(
+    'primary rejects Meta on %s',
+    (platform) => {
+      controller = new ModifierTriggerController(platform);
+      controller.handleKeyDown(keyEvent('Meta', { metaKey: true }), 'primary');
+
+      expect(controller.state).toBe(ModifierTriggerState.IDLE);
+      expect(controller.handleKeyUp(keyEvent('Meta'), 'primary')).toBe(false);
+    }
+  );
+
+  it('control accepts Control and rejects Meta on macOS', () => {
+    controller = new ModifierTriggerController(OS_PLATFORMS.MAC);
+    controller.handleKeyDown(keyEvent('Control', { ctrlKey: true }), 'control');
+
+    expect(controller.handleKeyUp(keyEvent('Control'), 'control')).toBe(true);
+
+    controller.handleKeyDown(keyEvent('Meta', { metaKey: true }), 'control');
+    expect(controller.state).toBe(ModifierTriggerState.IDLE);
+    expect(controller.handleKeyUp(keyEvent('Meta'), 'control')).toBe(false);
+  });
+
+  it('keeps Alt and Shift trigger identities unchanged on macOS', () => {
+    controller = new ModifierTriggerController(OS_PLATFORMS.MAC);
+    expect(getTriggerKeys('alt', OS_PLATFORMS.MAC)).toEqual(new Set(['Alt']));
+    expect(getTriggerKeys('shift', OS_PLATFORMS.MAC)).toEqual(new Set(['Shift']));
+
+    controller.handleKeyDown(keyEvent('Alt', { altKey: true }), 'alt');
+    expect(controller.handleKeyUp(keyEvent('Alt'), 'alt')).toBe(true);
+    controller.handleKeyDown(keyEvent('Shift', { shiftKey: true }), 'shift');
+    expect(controller.handleKeyUp(keyEvent('Shift'), 'shift')).toBe(true);
   });
 
   it('invalidates pending gesture on interaction and resets explicitly', () => {
-    controller.handleKeyDown(keyEvent('Control', { ctrlKey: true }), 'ctrl');
+    controller = new ModifierTriggerController(OS_PLATFORMS.WINDOWS);
+    controller.handleKeyDown(keyEvent('Control', { ctrlKey: true }), 'primary');
     controller.invalidate();
 
     expect(controller.state).toBe(ModifierTriggerState.INVALID);
-    expect(controller.handleKeyUp(keyEvent('Control'), 'ctrl')).toBe(false);
+    expect(controller.handleKeyUp(keyEvent('Control'), 'primary')).toBe(false);
 
-    controller.handleKeyDown(keyEvent('Control', { ctrlKey: true }), 'ctrl');
+    controller.handleKeyDown(keyEvent('Control', { ctrlKey: true }), 'primary');
     controller.reset();
 
     expect(controller.state).toBe(ModifierTriggerState.IDLE);

--- a/src/features/settings/stores/settings.test.js
+++ b/src/features/settings/stores/settings.test.js
@@ -232,6 +232,30 @@ describe('Settings Store', () => {
       expect(storageManager.set).toHaveBeenCalled();
     });
 
+    it('importSettings should pass legacy Mouse Hover triggers through centralized migration', async () => {
+      secureStorage.processImportedSettings.mockResolvedValueOnce({
+        THEME: 'dark',
+        MOUSE_HOVER_TRIGGER: 'ctrl'
+      });
+      const migrationInputs = [];
+      runSettingsMigrations.mockImplementationOnce(async (settings) => {
+        migrationInputs.push({ ...settings });
+        return {
+          updates: { MOUSE_HOVER_TRIGGER: 'primary' },
+          removals: [],
+          logs: ['Migrated MOUSE_HOVER_TRIGGER from ctrl to primary']
+        };
+      });
+      const store = useSettingsStore();
+
+      await store.importSettings({ THEME: 'dark', _exported: true });
+
+      expect(migrationInputs[0]).toEqual(
+        expect.objectContaining({ MOUSE_HOVER_TRIGGER: 'ctrl' })
+      );
+      expect(store.settings.MOUSE_HOVER_TRIGGER).toBe('primary');
+    });
+
     it('importSettings should drop non-editable wrappers from old backups and keep editable prompts', async () => {
       secureStorage.processImportedSettings.mockResolvedValue({
         THEME: 'dark',

--- a/src/shared/config/config.js
+++ b/src/shared/config/config.js
@@ -288,7 +288,7 @@ export const CONFIG = {
   // --- Mouse on Hover Translation Settings ---
   MOUSE_HOVER_TRANSLATION_ENABLED: false, // فعال بودن ترجمه با حرکت موس
   MOUSE_HOVER_SCOPE: 'container', // محدوده ترجمه: word, sentence, container
-  MOUSE_HOVER_TRIGGER: 'ctrl', // نحوه فعال‌سازی: hover, ctrl, alt, shift
+  MOUSE_HOVER_TRIGGER: 'primary', // نحوه فعال‌سازی: hover, primary, control, alt, shift
   MOUSE_HOVER_DELAY: 500, // زمان انتظار برای شروع ترجمه (میلی‌ثانیه)
   MOUSE_HOVER_AUTO_CLOSE: 'mouseleave', // نحوه بسته شدن: mouseleave, timer
   MOUSE_HOVER_TIMER_DURATION: 3000, // زمان نمایش تولتیپ در حالت timer (میلی‌ثانیه)

--- a/src/shared/config/settingsDefaults.test.js
+++ b/src/shared/config/settingsDefaults.test.js
@@ -39,6 +39,7 @@ describe('getPersistedDefaultSettings', () => {
     expect(defaults.GEMINI_THINKING_MODE).toBe('default');
     expect(defaults).not.toHaveProperty('OPENAI_API_URL');
     expect(defaults.TEXT_FIELD_SHORTCUT).toBe(CONFIG.TEXT_FIELD_SHORTCUT);
+    expect(defaults.MOUSE_HOVER_TRIGGER).toBe(CONFIG.MOUSE_HOVER_TRIGGER);
     expect(defaults.translationHistory).toBeUndefined();
     expect(defaults.PROMPT_TEMPLATE).toBe(CONFIG.PROMPT_TEMPLATE);
     expect(defaults.APP_NAME).toBeUndefined();

--- a/src/shared/config/settingsMigrations.js
+++ b/src/shared/config/settingsMigrations.js
@@ -50,6 +50,16 @@ const MODEL_VALUE_MIGRATIONS = {
 };
 
 /**
+ * Migrate the former ambiguous Ctrl trigger to the platform-aware primary modifier.
+ */
+function migrateMouseHoverTrigger(currentSettings, updates, migrationLog) {
+  if (currentSettings.MOUSE_HOVER_TRIGGER !== 'ctrl') return;
+
+  updates.MOUSE_HOVER_TRIGGER = 'primary';
+  migrationLog.push('Migrated MOUSE_HOVER_TRIGGER from ctrl to primary');
+}
+
+/**
  * Determine whether a value is a plain object.
  *
  * Only plain objects are candidates for recursive nested migration. Arrays,
@@ -201,6 +211,9 @@ function runMainMigration(currentSettings) {
 
   // Migrate Mode Provider keys first to ensure new structure is used
   migrateModeProviderKeys(currentSettings, updates, migrationLog);
+
+  // Migrate legacy Mouse Hover trigger values before filling missing defaults.
+  migrateMouseHoverTrigger(currentSettings, updates, migrationLog);
   
   // Migrate Bilingual Mode keys
   migrateBilingualModeKeys(currentSettings, updates, migrationLog);

--- a/src/shared/config/settingsMigrations.test.js
+++ b/src/shared/config/settingsMigrations.test.js
@@ -32,6 +32,36 @@ describe('Settings Migrations', () => {
     expect(updates.CHANGELOG_URL).toBeUndefined();
   });
 
+  it('should migrate the legacy Mouse Hover ctrl trigger to primary', async () => {
+    const { updates, logs } = await runSettingsMigrations({
+      MOUSE_HOVER_TRIGGER: 'ctrl'
+    });
+
+    expect(updates.MOUSE_HOVER_TRIGGER).toBe('primary');
+    expect(logs).toContain('Migrated MOUSE_HOVER_TRIGGER from ctrl to primary');
+  });
+
+  it.each(['hover', 'primary', 'control', 'alt', 'shift'])(
+    'should preserve canonical Mouse Hover trigger %s',
+    async (trigger) => {
+      const { updates } = await runSettingsMigrations({
+        MOUSE_HOVER_TRIGGER: trigger
+      });
+
+      expect(updates.MOUSE_HOVER_TRIGGER).toBeUndefined();
+    }
+  );
+
+  it('should make Mouse Hover trigger migration idempotent', async () => {
+    const first = await runSettingsMigrations({ MOUSE_HOVER_TRIGGER: 'ctrl' });
+    const second = await runSettingsMigrations({
+      MOUSE_HOVER_TRIGGER: first.updates.MOUSE_HOVER_TRIGGER
+    });
+
+    expect(first.updates.MOUSE_HOVER_TRIGGER).toBe('primary');
+    expect(second.updates.MOUSE_HOVER_TRIGGER).toBeUndefined();
+  });
+
   it('should not re-add non-editable prompt wrappers via missing-setting fill', async () => {
     const currentSettings = { THEME: 'dark' }; // Missing most things
     const { updates } = await runSettingsMigrations(currentSettings);

--- a/src/shared/managers/SettingsManager.js
+++ b/src/shared/managers/SettingsManager.js
@@ -110,7 +110,7 @@ class SettingsManager {
       // Mouse on Hover Translation Settings
       MOUSE_HOVER_TRANSLATION_ENABLED: false,
       MOUSE_HOVER_SCOPE: 'sentence',
-      MOUSE_HOVER_TRIGGER: 'hover',
+      MOUSE_HOVER_TRIGGER: CONFIG.MOUSE_HOVER_TRIGGER,
       MOUSE_HOVER_DELAY: 500,
       MOUSE_HOVER_AUTO_CLOSE: 'mouseleave',
       MOUSE_HOVER_TIMER_DURATION: 3000,


### PR DESCRIPTION
### Summary

Improves Mouse on Hover trigger behavior and prevents unintended translations while using normal keyboard shortcuts.

### Changes

* Trigger modifier translation only after a standalone modifier press/release.
* Prevent shortcuts such as `Ctrl+A`, `Ctrl+C`, and `Command+A` from triggering translation.
* Prevent mouse movement from independently triggering modifier mode.
* Add dedicated modifier gesture state handling.
* Add platform-aware modifier behavior:

  * Windows/Linux: `Ctrl`, `Alt`, `Shift`
  * macOS: `Command ⌘`, `Control ⌃`, `Option ⌥`, `Shift ⇧`
* Separate platform primary modifier from explicit Control.
* Migrate legacy `ctrl` trigger settings to `primary`.
* Preserve cross-platform imported settings.
* Update Mouse Hover defaults, UI labels, tests, and technical documentation.

### Verification

* Mouse Hover and settings tests passed.
* ESLint passed.
* i18n validation passed.
* `git diff --check` passed.

Ref #159
