### PR TITLE
Preserve Popup and Sidepanel translation state during browser session

### DIFF
--- a/src/apps/popup/PopupApp.test.js
+++ b/src/apps/popup/PopupApp.test.js
@@ -6,13 +6,17 @@ import PopupApp from './PopupApp.vue'
 let mockSettingsStore
 let mockUnifiedTranslation
 let mockLanguageDefaults
+const useUnifiedTranslationMock = vi.hoisted(() => vi.fn())
 
 vi.mock('@/features/settings/stores/settings.js', () => ({
   useSettingsStore: () => mockSettingsStore
 }))
 
 vi.mock('@/features/translation/composables/useUnifiedTranslation.js', () => ({
-  useUnifiedTranslation: () => mockUnifiedTranslation
+  useUnifiedTranslation: (...args) => {
+    useUnifiedTranslationMock(...args)
+    return mockUnifiedTranslation
+  }
 }))
 
 vi.mock('@/features/settings/composables/useLanguageDefaults.js', () => ({
@@ -120,7 +124,7 @@ vi.mock('@/components/shared/ProviderSelector.vue', () => ({
 vi.mock('@/components/popup/TranslationForm.vue', () => ({
   default: {
     name: 'TranslationForm',
-    props: ['sourceLanguage', 'targetLanguage', 'provider'],
+    props: ['sourceLanguage', 'targetLanguage', 'provider', 'translation'],
     template: '<div class="translation-form-stub" />'
   }
 }))
@@ -152,8 +156,10 @@ describe('PopupApp', () => {
       sourceText: ref('hello'),
       translatedText: ref('bonjour'),
       clearTranslation: vi.fn().mockResolvedValue(undefined),
+      initializeSessionState: vi.fn().mockResolvedValue(undefined),
       lastTranslation: ref({ source: 'hello' })
     }
+    useUnifiedTranslationMock.mockClear()
 
     mockLanguageDefaults = {
       savedSourceLanguage: ref('fr'),
@@ -186,6 +192,15 @@ describe('PopupApp', () => {
     expect(selector.props('defaultActionsEnabled')).toBe(true)
     expect(selector.props('sourceIsSavedDefault')).toBe(true)
     expect(selector.props('targetIsSavedDefault')).toBe(false)
+  })
+
+  it('creates one popup translation owner and passes it to TranslationForm', async () => {
+    const wrapper = mount(PopupApp)
+    await flushPromises()
+    await flushPromises()
+
+    expect(useUnifiedTranslationMock).toHaveBeenCalledTimes(1)
+    expect(wrapper.findComponent({ name: 'TranslationForm' }).props('translation')).toBe(mockUnifiedTranslation)
   })
 
   it('persists current source and target when stars are clicked', async () => {

--- a/src/apps/popup/PopupApp.vue
+++ b/src/apps/popup/PopupApp.vue
@@ -95,6 +95,7 @@
         <div class="translation-container">
           <TranslationForm
             ref="translationFormRef"
+            :translation="translation"
             :source-language="sourceLanguage"
             :target-language="targetLanguage"
             :provider="currentProvider"
@@ -154,12 +155,14 @@ const settingsStore = useSettingsStore()
 const { sendMessage } = useMessaging(MessageContexts.POPUP)
 const { handleError } = useErrorHandler()
 const { t } = useUnifiedI18n()
+const currentProvider = ref('')
+const translation = useUnifiedTranslation('popup', { provider: currentProvider });
 const { 
   sourceLanguage,
   targetLanguage,
   clearTranslation,
   lastTranslation
-} = useUnifiedTranslation('popup');
+} = translation;
 const {
   savedSourceLanguage,
   savedTargetLanguage,
@@ -185,7 +188,6 @@ const hasError = ref(false)
 const errorMessage = ref('')
 const errorType = ref(null)
 const canTranslateFromForm = ref(false)
-const currentProvider = ref('')
 
 // Reactive error message display with i18n support
 const displayErrorMessage = computed(() => {
@@ -289,6 +291,7 @@ const initialize = async () => {
     if (!currentProvider.value) {
       currentProvider.value = settings.TRANSLATION_API
     }
+    await translation.initializeSessionState()
 
     // Step 5: Global Event Listeners (e.g., clearing fields from other components)
     tracker.addEventListener(document, 'clear-storage', async () => {

--- a/src/apps/sidepanel/SidepanelLayout.vue
+++ b/src/apps/sidepanel/SidepanelLayout.vue
@@ -81,6 +81,8 @@ onMounted(async () => {
     manualProvider.value = defaultProvider
     logger.debug('[SidepanelLayout] Initialized manual translation provider:', manualProvider.value)
   }
+
+  await mainContentRef.value?.initializeSessionState?.()
 })
 
 // Watch for settings changes to keep global provider in sync

--- a/src/apps/sidepanel/components/SidepanelMainContent.test.js
+++ b/src/apps/sidepanel/components/SidepanelMainContent.test.js
@@ -32,7 +32,7 @@ const mockUnifiedTranslation = {
   getSettingsCallback: vi.fn(() => vi.fn()),
   cancelTranslation: vi.fn(),
   clearTranslation: vi.fn(),
-  loadLastTranslation: vi.fn().mockResolvedValue(undefined),
+  initializeSessionState: vi.fn().mockResolvedValue(undefined),
 };
 
 const mockLanguageDefaults = {

--- a/src/apps/sidepanel/components/SidepanelMainContent.vue
+++ b/src/apps/sidepanel/components/SidepanelMainContent.vue
@@ -177,6 +177,23 @@ const settingsStore = useSettingsStore()
 
 // Composables
 const { t } = useUnifiedI18n();
+
+// Props
+const props = defineProps({
+  provider: {
+    type: String,
+    default: ''
+  }
+})
+
+// Emits
+const emit = defineEmits(['can-translate-change', 'update:provider'])
+
+const currentProviderLocal = computed({
+  get: () => props.provider,
+  set: (value) => emit('update:provider', value)
+})
+
 const {
   sourceText,
   translatedText,
@@ -197,8 +214,8 @@ const {
   getSettingsCallback,
   cancelTranslation,
   clearTranslation,
-  loadLastTranslation
-} = useUnifiedTranslation('sidepanel');
+  initializeSessionState
+} = useUnifiedTranslation('sidepanel', { provider: currentProviderLocal });
 const {
   savedSourceLanguage,
   savedTargetLanguage,
@@ -215,23 +232,6 @@ const { handleError } = useErrorHandler()
 // Refs
 const sourceInputRef = ref(null)
 const translationResultRef = ref(null)
-
-// Props
-const props = defineProps({
-  provider: {
-    type: String,
-    default: ''
-  }
-})
-
-// Emits
-const emit = defineEmits(['can-translate-change', 'update:provider'])
-
-// State
-const currentProviderLocal = computed({
-  get: () => props.provider,
-  set: (value) => emit('update:provider', value)
-})
 
 const retryTranslation = getRetryCallback(() => triggerTranslation(
   sourceLanguage.value,
@@ -370,16 +370,14 @@ const handleSetDefaultTarget = async () => {
 // Expose methods and refs to the parent component
 defineExpose({
   clearFields,
-  sourceInputRef
+  sourceInputRef,
+  initializeSessionState
 });
 
 
 // Event listeners
 onMounted(async () => {
   logger.debug("[SidepanelMainContent] Component mounting...");
-  // Language initialization is now handled by useUnifiedTranslation.
-  // Load last translation if any
-  await loadLastTranslation()
 
   // Setup resize observer for responsive layout
   // Use setTimeout to ensure DOM is ready and initial width is calculated

--- a/src/components/popup/TranslationForm.test.js
+++ b/src/components/popup/TranslationForm.test.js
@@ -22,7 +22,7 @@ const mockTranslation = {
   getSettingsCallback: vi.fn(() => mockSettingsCallback),
   cancelTranslation: vi.fn(),
   clearTranslation: vi.fn(),
-  loadLastTranslation: vi.fn().mockResolvedValue(undefined),
+  revertTranslation: vi.fn(),
 };
 
 vi.mock('@/features/translation/composables/useUnifiedTranslation.js', () => ({
@@ -96,6 +96,7 @@ describe('TranslationForm.vue', () => {
       sourceLanguage: 'en',
       targetLanguage: 'fr',
       provider: 'openai',
+      translation: mockTranslation,
     },
   });
 

--- a/src/components/popup/TranslationForm.vue
+++ b/src/components/popup/TranslationForm.vue
@@ -53,7 +53,6 @@
 
 <script setup>
 import { ref, onMounted, watch } from 'vue'
-import { useUnifiedTranslation } from '@/features/translation/composables/useUnifiedTranslation.js'
 import { useSettingsStore } from '@/features/settings/stores/settings.js'
 import { useErrorHandler } from '@/composables/shared/useErrorHandler.js'
 import { useUnifiedI18n } from '@/composables/shared/useUnifiedI18n.js'
@@ -85,6 +84,10 @@ const props = defineProps({
   provider: {
     type: String,
     default: ''
+  },
+  translation: {
+    type: Object,
+    required: true
   }
 })
 
@@ -94,8 +97,6 @@ const settingsStore = useSettingsStore()
 // Emits
 const emit = defineEmits(['can-translate-change'])
 
-// Composables (lightweight popup version)
-const translation = useUnifiedTranslation('popup')
 const { handleError } = useErrorHandler()
 const { t } = useUnifiedI18n()
 
@@ -122,8 +123,8 @@ const {
   getSettingsCallback,
   cancelTranslation,
   clearTranslation,
-  loadLastTranslation
-} = translation
+  revertTranslation: revertCurrentTranslation
+} = props.translation
 
 const retryTranslation = getRetryCallback(() => triggerTranslation(
   props.sourceLanguage,
@@ -198,18 +199,10 @@ const clearStorage = () => {
 }
 
 const revertTranslation = () => {
-  if (lastTranslation.value) {
-    sourceText.value = lastTranslation.value.target || ''
-    translatedText.value = lastTranslation.value.source || ''
-    
-    // Swap languages too
-    const tempSource = lastTranslation.value.targetLanguage
-    const tempTarget = lastTranslation.value.sourceLanguage
-    
-    if (tempSource && tempTarget) {
-      settingsStore.updateSettingAndPersist('SOURCE_LANGUAGE', tempSource)
-      settingsStore.updateSettingAndPersist('TARGET_LANGUAGE', tempTarget)
-    }
+  const languages = revertCurrentTranslation()
+  if (languages?.sourceLanguage && languages?.targetLanguage) {
+    settingsStore.updateSettingAndPersist('SOURCE_LANGUAGE', languages.sourceLanguage)
+    settingsStore.updateSettingAndPersist('TARGET_LANGUAGE', languages.targetLanguage)
   }
 }
 
@@ -226,8 +219,6 @@ onMounted(async () => {
     // Text content should remain in their respective fields
   })
   
-  // Initialize translation data
-  await loadLastTranslation()
 })
 
 // Expose methods and state to parent

--- a/src/features/translation/composables/useUnifiedTranslation.js
+++ b/src/features/translation/composables/useUnifiedTranslation.js
@@ -22,6 +22,7 @@ import { AUTO_DETECT_VALUE, DEFAULT_TARGET_LANGUAGE } from "@/shared/constants/c
 import { utilsFactory } from "@/utils/UtilsFactory.js";
 import { registerTranslation, handleMessage as routeMessage } from "@/shared/messaging/core/ContentScriptIntegration.js";
 import { sendMessage as sendUnifiedMessage } from '@/shared/messaging/core/UnifiedMessaging.js';
+import { translationUiSessionState } from '@/features/translation/storage/TranslationUiSessionState.js';
 
 // Lazy logger to avoid TDZ ReferenceErrors when bundled
 const logger = new Proxy({}, {
@@ -45,7 +46,7 @@ function resolveFailureError(payload) {
 /**
  * useUnifiedTranslation - Unified composable for translation features
  */
-export function useUnifiedTranslation(context = 'popup') {
+export function useUnifiedTranslation(context = 'popup', { provider = null } = {}) {
   // Validate context
   const validContexts = ['popup', 'sidepanel'];
   if (!validContexts.includes(context)) {
@@ -98,7 +99,12 @@ export function useUnifiedTranslation(context = 'popup') {
   const pendingRequests = ref(new Set());
   const loadingStartTime = ref(null);
   const currentMessageId = ref(null);
+  const activeRequestSource = ref(null);
   const lastSyncedTimestamp = ref(0);
+  let sessionRevision = 0;
+  let sessionReady = false;
+  let sessionResultEligible = false;
+  let expectedProgrammaticSource = null;
   const MINIMUM_LOADING_DURATION = 100;
 
   /**
@@ -119,7 +125,10 @@ export function useUnifiedTranslation(context = 'popup') {
       isTranslating.value = false;
       isStreaming.value = false;
       currentMessageId.value = null;
+      activeRequestSource.value = null;
       loadingStartTime.value = null;
+      sessionResultEligible = false;
+      void persistSessionState();
     } catch (error) {
       logger.error(`[${context}] Failed to cancel translation:`, error);
     }
@@ -136,6 +145,89 @@ export function useUnifiedTranslation(context = 'popup') {
   const canTranslate = computed(
     () => Boolean(sourceText.value?.trim()) && !isTranslating.value
   );
+
+  const getSessionProvider = () => provider?.value || null;
+
+  const createSessionSnapshot = () => {
+    const draftSource = sourceText.value || '';
+    const translation = lastTranslation.value;
+    const canRestoreCompletedTranslation = sessionResultEligible
+      && !isTranslating.value
+      && !isStreaming.value
+      && translation?.source === draftSource;
+
+    return {
+      draftSource,
+      sourceLanguage: sourceLanguage.value,
+      targetLanguage: targetLanguage.value,
+      provider: getSessionProvider(),
+      revision: ++sessionRevision,
+      completedTranslation: canRestoreCompletedTranslation ? {
+        source: translation.source,
+        displayTranslatedText: translatedText.value,
+        translationTarget: translation.target,
+        sourceLanguage: translation.sourceLanguage,
+        targetLanguage: translation.targetLanguage,
+        provider: translation.provider,
+        actualSourceLanguage: actualSourceLanguage.value,
+        actualTargetLanguage: actualTargetLanguage.value,
+        mode: translation.mode,
+        timestamp: translation.timestamp,
+      } : null,
+    };
+  };
+
+  const persistSessionState = () => {
+    if (!sessionReady) return Promise.resolve(false);
+    if (!sourceText.value) return clearSessionState();
+    return translationUiSessionState.save(context, createSessionSnapshot());
+  };
+
+  const clearSessionState = () => {
+    sessionResultEligible = false;
+    sessionRevision += 1;
+    return translationUiSessionState.clear(context, sessionRevision);
+  };
+
+  const initializeSessionState = async () => {
+    await resetLanguagesToDefaults();
+
+    const snapshot = await translationUiSessionState.load(context);
+    if (!snapshot || typeof snapshot.draftSource !== 'string') {
+      sessionReady = true;
+      return false;
+    }
+
+    sessionRevision = Math.max(sessionRevision, Number(snapshot.revision) || 0);
+    sourceText.value = snapshot.draftSource;
+    sourceLanguage.value = snapshot.sourceLanguage || sourceLanguage.value;
+    targetLanguage.value = snapshot.targetLanguage || targetLanguage.value;
+    if (provider && snapshot.provider) provider.value = snapshot.provider;
+
+    const completed = snapshot.completedTranslation;
+    if (completed?.source === snapshot.draftSource) {
+      translatedText.value = completed.displayTranslatedText || '';
+      actualSourceLanguage.value = completed.actualSourceLanguage || completed.sourceLanguage || sourceLanguage.value;
+      actualTargetLanguage.value = completed.actualTargetLanguage || completed.targetLanguage || targetLanguage.value;
+      lastSyncedTimestamp.value = completed.timestamp || 0;
+      lastTranslation.value = {
+        source: completed.source,
+        target: completed.translationTarget,
+        sourceLanguage: completed.sourceLanguage,
+        targetLanguage: completed.targetLanguage,
+        provider: completed.provider,
+        mode: completed.mode,
+        timestamp: completed.timestamp,
+      };
+      sessionResultEligible = true;
+    } else {
+      translatedText.value = '';
+      lastTranslation.value = null;
+    }
+
+    sessionReady = true;
+    return true;
+  };
 
   /**
    * Returns the actual language detected by the provider/service during the last translation.
@@ -176,6 +268,7 @@ export function useUnifiedTranslation(context = 'popup') {
       // Also update actual language to reflect user's choice when manual selection changes
       actualTargetLanguage.value = newVal;
     }
+    void persistSessionState();
   });
 
   // Watch for local sourceLanguage changes
@@ -183,20 +276,39 @@ export function useUnifiedTranslation(context = 'popup') {
     if (newVal) {
       actualSourceLanguage.value = newVal;
     }
+    void persistSessionState();
   });
 
   // Reset lastTranslation when source text changes to ensure fresh detection for TTS
   // We keep translatedText as-is to prevent immediate UI clearing (better UX)
   watch(sourceText, (newVal, oldVal) => {
     if (newVal !== oldVal) {
+      const isExpectedProgrammaticChange = newVal === expectedProgrammaticSource;
+      expectedProgrammaticSource = null;
+      if (isExpectedProgrammaticChange) {
+        void persistSessionState();
+        return;
+      }
       // Don't clear if this change came from a store sync (source matches store)
       const ct = translationStore.currentTranslation;
       if (ct && ct.sourceText === newVal && ct.timestamp === lastSyncedTimestamp.value) {
         return;
       }
       lastTranslation.value = null;
+      sessionResultEligible = false;
     }
+    if (!newVal) {
+      void clearSessionState();
+      return;
+    }
+    void persistSessionState();
   });
+
+  if (provider) {
+    watch(provider, () => {
+      void persistSessionState();
+    });
+  }
 
   // Watch for store changes to update local targetLanguage (for cross-component sync)
   watch(() => translationStore.uiTargetLanguage, (newVal) => {
@@ -238,7 +350,12 @@ export function useUnifiedTranslation(context = 'popup') {
     };
   };
 
-  const handleTranslationSuccess = (resultData) => {
+  const handleTranslationSuccess = (resultData, requestSource) => {
+    if (requestSource !== sourceText.value) {
+      logger.debug(`[${context}] Ignoring stale translation result for changed source text`);
+      return false;
+    }
+
     translatedText.value = resultData.translatedText;
     errorManager.clearError();
     
@@ -269,6 +386,8 @@ export function useUnifiedTranslation(context = 'popup') {
     }
 
     logger.debug(`[${context}] Translation updated successfully - final translatedText: "${translatedText.value}"`);
+    sessionResultEligible = true;
+    return true;
   };
 
   const handleTranslationError = (error, messageId = null) => {
@@ -276,12 +395,14 @@ export function useUnifiedTranslation(context = 'popup') {
     translatedText.value = "";
     lastTranslation.value = null;
     lastSyncedTimestamp.value = 0;
+    sessionResultEligible = false;
     
     if (messageId && context === 'sidepanel') {
       pendingRequests.value.delete(messageId);
     }
     
     logger.debug(`[${context}] Translation error:`, error?.message || error);
+    void persistSessionState();
   };
 
   const ensureMinimumLoadingDuration = async () => {
@@ -312,6 +433,7 @@ export function useUnifiedTranslation(context = 'popup') {
 
     isTranslating.value = true;
     isStreaming.value = false;
+    sessionResultEligible = false;
     if (context === 'sidepanel') {
       loadingStartTime.value = Date.now();
     }
@@ -323,6 +445,8 @@ export function useUnifiedTranslation(context = 'popup') {
     try {
       const messageId = generateMessageId(context);
       currentMessageId.value = messageId;
+      activeRequestSource.value = sourceText.value;
+      void persistSessionState();
 
       // Track accumulated streaming results
       const accumulatedResults = new Map();
@@ -330,6 +454,7 @@ export function useUnifiedTranslation(context = 'popup') {
       // Register for streaming updates
       registerTranslation(messageId, {
         onStreamUpdate: (data) => {
+          if (activeRequestSource.value !== sourceText.value) return;
           if (data.data) {
             const batchText = Array.isArray(data.data) ? data.data.join('') : String(data.data);
             
@@ -386,7 +511,7 @@ export function useUnifiedTranslation(context = 'popup') {
         if (resultData.success === false && (resultData.error || resultData.errorDetails)) {
           handleTranslationError(resolveFailureError(resultData), messageId);
         } else if (resultData.success === true && resultData.translatedText !== undefined) {
-          handleTranslationSuccess(resultData);
+          handleTranslationSuccess(resultData, activeRequestSource.value);
           if (context === 'sidepanel') {
             pendingRequests.value.delete(messageId);
             await ensureMinimumLoadingDuration();
@@ -395,6 +520,8 @@ export function useUnifiedTranslation(context = 'popup') {
         isTranslating.value = false;
         isStreaming.value = false;
         currentMessageId.value = null;
+        activeRequestSource.value = null;
+        void persistSessionState();
         logger.debug(`[${context}] Direct response processed successfully`);
         return true;
       } else if (response && response.success === false && (response.error || response.errorDetails)) {
@@ -402,12 +529,16 @@ export function useUnifiedTranslation(context = 'popup') {
         isTranslating.value = false;
         isStreaming.value = false;
         currentMessageId.value = null;
+        activeRequestSource.value = null;
+        void persistSessionState();
         return false;
       } else {
         logger.warn(`[${context}] No valid response received`, response);
         isTranslating.value = false;
         isStreaming.value = false;
         currentMessageId.value = null;
+        activeRequestSource.value = null;
+        void persistSessionState();
         return false;
       }
 
@@ -427,13 +558,16 @@ export function useUnifiedTranslation(context = 'popup') {
       isTranslating.value = false;
       isStreaming.value = false;
       currentMessageId.value = null;
+      activeRequestSource.value = null;
       await ensureMinimumLoadingDuration();
+      void persistSessionState();
       return false;
     }
   };
 
   // --- Public Methods ---
   const clearTranslation = async () => {
+    await clearSessionState();
     sourceText.value = "";
     translatedText.value = "";
     errorManager.clearError();
@@ -442,12 +576,37 @@ export function useUnifiedTranslation(context = 'popup') {
     await resetLanguagesToDefaults();
   };
 
-  const loadLastTranslation = () => {
-    if (lastTranslation.value) {
-      sourceText.value = lastTranslation.value.source;
-      translatedText.value = lastTranslation.value.target;
-      lastSyncedTimestamp.value = lastTranslation.value.timestamp;
-    }
+  const revertTranslation = () => {
+    const translation = lastTranslation.value;
+    if (!translation) return null;
+
+    const revertedSource = translation.target || '';
+    expectedProgrammaticSource = revertedSource;
+    sourceText.value = revertedSource;
+    translatedText.value = translation.source || '';
+    sourceLanguage.value = translation.targetLanguage || sourceLanguage.value;
+    targetLanguage.value = translation.sourceLanguage || targetLanguage.value;
+    actualSourceLanguage.value = translation.targetLanguage || actualSourceLanguage.value;
+    actualTargetLanguage.value = translation.sourceLanguage || actualTargetLanguage.value;
+
+    const timestamp = Date.now();
+    lastSyncedTimestamp.value = timestamp;
+    lastTranslation.value = {
+      source: sourceText.value,
+      target: translatedText.value,
+      sourceLanguage: sourceLanguage.value,
+      targetLanguage: targetLanguage.value,
+      provider: translation.provider,
+      mode: translation.mode,
+      timestamp,
+    };
+    sessionResultEligible = true;
+    void persistSessionState();
+
+    return {
+      sourceLanguage: sourceLanguage.value,
+      targetLanguage: targetLanguage.value,
+    };
   };
 
   // --- Lifecycle & Watchers ---
@@ -460,14 +619,14 @@ export function useUnifiedTranslation(context = 'popup') {
       sourceLanguage.value = await findLanguageCode(newTranslation.sourceLanguage) || AUTO_DETECT_VALUE;
       targetLanguage.value = await findLanguageCode(newTranslation.targetLanguage) || DEFAULT_TARGET_LANGUAGE;
       errorManager.clearError();
+      sessionResultEligible = sourceText.value === newTranslation.sourceText;
+      void persistSessionState();
     }
   }, { deep: true });
 
   let messageListener = null;
 
   onMounted(async () => {
-    await resetLanguagesToDefaults();
-
     messageListener = (message, sender) => {
       // Route through ContentScriptIntegration for streaming and unified handling
       const handledByIntegration = routeMessage(message, sender);
@@ -491,18 +650,22 @@ export function useUnifiedTranslation(context = 'popup') {
       // 2. Handle Translation Results (Fallback/Direct)
       if (context === 'popup') {
         logger.debug(`[${context}] Message listener triggered - isTranslating: ${isTranslating.value}`);
+        if (message.messageId && message.messageId !== currentMessageId.value) return;
         let resultData = message.result || message.data || (message.translatedText ? message : null);
 
         if (resultData && (resultData.translatedText !== undefined || resultData.success === false || resultData.success === true)) {
           if (resultData.success === false && (resultData.error || resultData.errorDetails)) {
             handleTranslationError(resolveFailureError(resultData));
           } else if (resultData.success === true && resultData.translatedText !== undefined) {
-            handleTranslationSuccess(resultData);
+            handleTranslationSuccess(resultData, activeRequestSource.value);
           } else {
             handleTranslationError("Unexpected response format");
           }
           isTranslating.value = false;
           isStreaming.value = false;
+          currentMessageId.value = null;
+          activeRequestSource.value = null;
+          void persistSessionState();
         }
       } else if (context === 'sidepanel') {
         if (message.action !== MessageActions.TRANSLATION_RESULT_UPDATE || (message.context && message.context !== MessagingContexts.SIDEPANEL)) {
@@ -519,10 +682,13 @@ export function useUnifiedTranslation(context = 'popup') {
           if (message.data.success === false && (message.data.error || message.data.errorDetails)) {
             handleTranslationError(resolveFailureError(message.data));
           } else if (message.data.success === true && message.data.translatedText !== undefined) {
-            handleTranslationSuccess(message.data);
+            handleTranslationSuccess(message.data, activeRequestSource.value);
           } else {
             handleTranslationError("Unexpected response format in sidepanel");
           }
+          currentMessageId.value = null;
+          activeRequestSource.value = null;
+          void persistSessionState();
         });
       }
     };
@@ -569,7 +735,8 @@ export function useUnifiedTranslation(context = 'popup') {
     triggerTranslation,
     cancelTranslation,
     clearTranslation,
-    loadLastTranslation,
+    revertTranslation,
+    initializeSessionState,
     getRetryCallback: errorManager.getRetryCallback,
     getSettingsCallback: errorManager.getSettingsCallback,
     // Context

--- a/src/features/translation/composables/useUnifiedTranslation.test.js
+++ b/src/features/translation/composables/useUnifiedTranslation.test.js
@@ -5,6 +5,17 @@ import { useUnifiedTranslation } from './useUnifiedTranslation.js';
 
 // --- Mocks ---
 
+const sessionMocks = vi.hoisted(() => ({
+  load: vi.fn(),
+  save: vi.fn(),
+  clear: vi.fn(),
+}));
+
+const contentIntegrationMocks = vi.hoisted(() => ({
+  registerTranslation: vi.fn(),
+  handleMessage: vi.fn(() => false),
+}));
+
 vi.mock("webextension-polyfill", () => ({
   default: {
     runtime: {
@@ -15,6 +26,12 @@ vi.mock("webextension-polyfill", () => ({
     },
   },
 }));
+
+vi.mock('@/features/translation/storage/TranslationUiSessionState.js', () => ({
+  translationUiSessionState: sessionMocks,
+}));
+
+vi.mock('@/shared/messaging/core/ContentScriptIntegration.js', () => contentIntegrationMocks);
 
 vi.mock("@/shared/logging/logger.js", () => ({
   getScopedLogger: vi.fn(() => ({
@@ -138,6 +155,10 @@ describe("useUnifiedTranslation", () => {
     translationStore = useTranslationStore();
     vi.useFakeTimers();
     vi.clearAllMocks();
+    sessionMocks.load.mockResolvedValue(null);
+    sessionMocks.save.mockResolvedValue(true);
+    sessionMocks.clear.mockResolvedValue(true);
+    contentIntegrationMocks.handleMessage.mockReturnValue(false);
   });
 
   afterEach(() => {
@@ -350,11 +371,261 @@ describe("useUnifiedTranslation", () => {
 
   it("should clear translation", async () => {
     const [composable] = withSetup(() => useUnifiedTranslation("popup"));
+    await composable.initializeSessionState();
     composable.sourceText.value = "Some text";
     composable.translatedText.value = "Some translation";
     await composable.clearTranslation();
     expect(composable.sourceText.value).toBe("");
     expect(composable.translatedText.value).toBe("");
+    expect(sessionMocks.clear).toHaveBeenCalledWith('popup', expect.any(Number));
+  });
+
+  it('restores a context-local draft and provider', async () => {
+    const provider = ref('default');
+    sessionMocks.load.mockResolvedValue({
+      draftSource: 'Popup draft',
+      sourceLanguage: 'en',
+      targetLanguage: 'fa',
+      provider: 'deepl',
+      revision: 4,
+      completedTranslation: null,
+    });
+    const [composable] = withSetup(() => useUnifiedTranslation('popup', { provider }));
+
+    await composable.initializeSessionState();
+
+    expect(composable.sourceText.value).toBe('Popup draft');
+    expect(composable.translatedText.value).toBe('');
+    expect(composable.sourceLanguage.value).toBe('en');
+    expect(composable.targetLanguage.value).toBe('fa');
+    expect(provider.value).toBe('deepl');
+  });
+
+  it('restores a completed translation only when it matches saved draft source', async () => {
+    sessionMocks.load.mockResolvedValue({
+      draftSource: 'Hello',
+      revision: 2,
+      completedTranslation: {
+        source: 'Hello',
+        displayTranslatedText: 'سلام',
+        translationTarget: 'سلام',
+        sourceLanguage: 'en',
+        targetLanguage: 'fa',
+        provider: 'google_v2',
+        actualSourceLanguage: 'en',
+        actualTargetLanguage: 'fa',
+        timestamp: 1,
+      },
+    });
+    const [composable] = withSetup(() => useUnifiedTranslation('popup'));
+
+    await composable.initializeSessionState();
+
+    expect(composable.sourceText.value).toBe('Hello');
+    expect(composable.translatedText.value).toBe('سلام');
+    expect(composable.lastTranslation.value).toMatchObject({ source: 'Hello', target: 'سلام' });
+  });
+
+  it('persists draft-only after source edit following a restored result', async () => {
+    sessionMocks.load.mockResolvedValue({
+      draftSource: 'Hello',
+      revision: 2,
+      completedTranslation: {
+        source: 'Hello',
+        displayTranslatedText: 'سلام',
+        translationTarget: 'سلام',
+        sourceLanguage: 'en',
+        targetLanguage: 'fa',
+        timestamp: 1,
+      },
+    });
+    const [composable] = withSetup(() => useUnifiedTranslation('popup'));
+    await composable.initializeSessionState();
+
+    composable.sourceText.value = 'Hello again';
+    await nextTick();
+
+    expect(sessionMocks.save).toHaveBeenLastCalledWith('popup', expect.objectContaining({
+      draftSource: 'Hello again',
+      completedTranslation: null,
+    }));
+  });
+
+  it('clears only its session snapshot when source becomes empty', async () => {
+    const [composable] = withSetup(() => useUnifiedTranslation('sidepanel'));
+    await composable.initializeSessionState();
+    composable.sourceText.value = 'draft';
+    await nextTick();
+    composable.sourceText.value = '';
+    await nextTick();
+
+    expect(sessionMocks.clear).toHaveBeenCalledWith('sidepanel', expect.any(Number));
+    expect(sessionMocks.clear).not.toHaveBeenCalledWith('popup', expect.any(Number));
+  });
+
+  it('persists and restores same-language display text without rewriting canonical target', async () => {
+    const [composable] = withSetup(() => useUnifiedTranslation('popup'));
+    await composable.initializeSessionState();
+    const { sendMessage } = await import("@/shared/messaging/core/UnifiedMessaging.js");
+    sendMessage.mockResolvedValue({
+      success: true,
+      translatedText: null,
+      originalText: 'Hello',
+      sourceLanguage: 'en',
+      targetLanguage: 'en',
+    });
+    composable.sourceText.value = 'Hello';
+
+    await composable.triggerTranslation();
+
+    expect(composable.translatedText.value).toBe('Hello');
+    const snapshot = sessionMocks.save.mock.lastCall[1];
+    expect(snapshot.completedTranslation).toMatchObject({
+      source: 'Hello',
+      displayTranslatedText: 'Hello',
+      translationTarget: null,
+    });
+    expect(snapshot.completedTranslation).not.toHaveProperty('sameLanguage');
+
+    setActivePinia(createPinia());
+    sessionMocks.load.mockResolvedValue(snapshot);
+    const [restored] = withSetup(() => useUnifiedTranslation('popup'));
+    await restored.initializeSessionState();
+
+    expect(restored.translatedText.value).toBe('Hello');
+    expect(restored.lastTranslation.value.target).toBeNull();
+  });
+
+  it('persists and restores a reversed Popup translation pair', async () => {
+    sessionMocks.load.mockResolvedValue({
+      draftSource: 'Hello',
+      revision: 2,
+      completedTranslation: {
+        source: 'Hello',
+        displayTranslatedText: 'سلام',
+        translationTarget: 'سلام',
+        sourceLanguage: 'en',
+        targetLanguage: 'fa',
+        provider: 'google_v2',
+        actualSourceLanguage: 'en',
+        actualTargetLanguage: 'fa',
+        timestamp: 1,
+      },
+    });
+    const [composable] = withSetup(() => useUnifiedTranslation('popup'));
+    await composable.initializeSessionState();
+
+    composable.revertTranslation();
+    await nextTick();
+
+    const snapshot = sessionMocks.save.mock.lastCall[1];
+    expect(snapshot.completedTranslation).toMatchObject({
+      source: 'سلام',
+      displayTranslatedText: 'Hello',
+      translationTarget: 'Hello',
+    });
+
+    setActivePinia(createPinia());
+    sessionMocks.load.mockResolvedValue(snapshot);
+    const [restored] = withSetup(() => useUnifiedTranslation('popup'));
+    await restored.initializeSessionState();
+
+    expect(restored.sourceText.value).toBe('سلام');
+    expect(restored.translatedText.value).toBe('Hello');
+  });
+
+  it('invalidates a same-source revert on the next real source edit', async () => {
+    sessionMocks.load.mockResolvedValue({
+      draftSource: 'OpenAI',
+      revision: 2,
+      completedTranslation: {
+        source: 'OpenAI',
+        displayTranslatedText: 'OpenAI',
+        translationTarget: 'OpenAI',
+        sourceLanguage: 'en',
+        targetLanguage: 'en',
+        provider: 'google_v2',
+        actualSourceLanguage: 'en',
+        actualTargetLanguage: 'en',
+        timestamp: 1,
+      },
+    });
+    const [composable] = withSetup(() => useUnifiedTranslation('popup'));
+    await composable.initializeSessionState();
+
+    composable.revertTranslation();
+    expect(composable.sourceText.value).toBe('OpenAI');
+
+    composable.sourceText.value = 'OpenAI test';
+    await nextTick();
+
+    expect(composable.lastTranslation.value).toBeNull();
+    expect(sessionMocks.save).toHaveBeenLastCalledWith('popup', expect.objectContaining({
+      draftSource: 'OpenAI test',
+      completedTranslation: null,
+    }));
+  });
+
+  it('persists draft-only while streaming and after cancellation or failure', async () => {
+    let resolveRequest;
+    const [composable] = withSetup(() => useUnifiedTranslation('popup'));
+    await composable.initializeSessionState();
+    const { sendMessage } = await import("@/shared/messaging/core/UnifiedMessaging.js");
+    sendMessage
+      .mockImplementationOnce(() => new Promise(resolve => { resolveRequest = resolve; }))
+      .mockResolvedValueOnce(undefined);
+    composable.sourceText.value = 'draft';
+
+    const request = composable.triggerTranslation();
+    await nextTick();
+    contentIntegrationMocks.registerTranslation.mock.calls[0][1].onStreamUpdate({ data: 'partial' });
+
+    expect(sessionMocks.save).toHaveBeenLastCalledWith('popup', expect.objectContaining({
+      draftSource: 'draft',
+      completedTranslation: null,
+    }));
+
+    await composable.cancelTranslation();
+    await nextTick();
+    expect(sessionMocks.save).toHaveBeenLastCalledWith('popup', expect.objectContaining({
+      draftSource: 'draft',
+      completedTranslation: null,
+    }));
+
+    resolveRequest({ success: false, error: 'failed' });
+    await request;
+
+    expect(sessionMocks.save).toHaveBeenLastCalledWith('popup', expect.objectContaining({
+      draftSource: 'draft',
+      completedTranslation: null,
+    }));
+  });
+
+  it('does not let an older completion overwrite a newer draft snapshot', async () => {
+    let resolveRequest;
+    const [composable] = withSetup(() => useUnifiedTranslation('popup'));
+    await composable.initializeSessionState();
+    const { sendMessage } = await import("@/shared/messaging/core/UnifiedMessaging.js");
+    sendMessage.mockImplementation(() => new Promise(resolve => { resolveRequest = resolve; }));
+    composable.sourceText.value = 'old draft';
+
+    const request = composable.triggerTranslation();
+    composable.sourceText.value = 'new draft';
+    await nextTick();
+    resolveRequest({
+      success: true,
+      translatedText: 'old result',
+      originalText: 'old draft',
+      sourceLanguage: 'en',
+      targetLanguage: 'fa',
+    });
+    await request;
+
+    expect(composable.sourceText.value).toBe('new draft');
+    expect(sessionMocks.save).toHaveBeenLastCalledWith('popup', expect.objectContaining({
+      draftSource: 'new draft',
+      completedTranslation: null,
+    }));
   });
 
   it("should update when translationStore.currentTranslation changes", async () => {

--- a/src/features/translation/storage/TranslationUiSessionState.js
+++ b/src/features/translation/storage/TranslationUiSessionState.js
@@ -1,0 +1,93 @@
+import browser from 'webextension-polyfill';
+import { getScopedLogger } from '@/shared/logging/logger.js';
+import { LOG_COMPONENTS } from '@/shared/logging/logConstants.js';
+
+const logger = getScopedLogger(LOG_COMPONENTS.TRANSLATION, 'translation-ui-session');
+const CONTEXTS = new Set(['popup', 'sidepanel']);
+const revisions = new Map();
+const queues = new Map();
+
+function getKey(context) {
+  if (!CONTEXTS.has(context)) throw new Error(`Unsupported translation UI context: ${context}`);
+  return `translation-ui-session:${context}`;
+}
+
+function getSessionStorage() {
+  try {
+    return browser?.storage?.session;
+  } catch {
+    return null;
+  }
+}
+
+function enqueue(key, operation) {
+  const previous = queues.get(key) || Promise.resolve();
+  const next = previous.catch(() => {}).then(operation);
+  queues.set(key, next);
+  return next.finally(() => {
+    if (queues.get(key) === next) queues.delete(key);
+  });
+}
+
+export const translationUiSessionState = {
+  getKey,
+
+  async load(context) {
+    const storage = getSessionStorage();
+    if (typeof storage?.get !== 'function') return null;
+
+    const key = getKey(context);
+    try {
+      const snapshot = (await storage.get(key))[key] || null;
+      const revision = Number(snapshot?.revision);
+      if (Number.isFinite(revision)) {
+        revisions.set(key, Math.max(revisions.get(key) || 0, revision));
+      }
+      return snapshot;
+    } catch (error) {
+      logger.warn(`[${context}] Failed to load translation UI session state:`, error);
+      return null;
+    }
+  },
+
+  save(context, snapshot) {
+    const storage = getSessionStorage();
+    if (typeof storage?.set !== 'function') return Promise.resolve(false);
+
+    const key = getKey(context);
+    const revision = Number(snapshot?.revision) || 0;
+    if (revision < (revisions.get(key) || 0)) return Promise.resolve(false);
+    revisions.set(key, revision);
+
+    return enqueue(key, async () => {
+      if (revision !== revisions.get(key)) return false;
+      try {
+        await storage.set({ [key]: snapshot });
+        return true;
+      } catch (error) {
+        logger.warn(`[${context}] Failed to save translation UI session state:`, error);
+        return false;
+      }
+    });
+  },
+
+  clear(context, revision = 0) {
+    const storage = getSessionStorage();
+    if (typeof storage?.remove !== 'function') return Promise.resolve(false);
+
+    const key = getKey(context);
+    if (revision < (revisions.get(key) || 0)) return Promise.resolve(false);
+    revisions.set(key, revision);
+
+    return enqueue(key, async () => {
+      if (revision !== revisions.get(key)) return false;
+      try {
+        await storage.remove(key);
+        return true;
+      } catch (error) {
+        logger.warn(`[${context}] Failed to clear translation UI session state:`, error);
+        return false;
+      }
+    });
+  },
+};

--- a/src/features/translation/storage/TranslationUiSessionState.test.js
+++ b/src/features/translation/storage/TranslationUiSessionState.test.js
@@ -1,0 +1,120 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import browser from 'webextension-polyfill';
+import { translationUiSessionState } from './TranslationUiSessionState.js';
+
+const mocks = vi.hoisted(() => ({
+  get: vi.fn(),
+  set: vi.fn(),
+  remove: vi.fn(),
+}));
+
+function deferred() {
+  let resolve;
+  const promise = new Promise(nextResolve => { resolve = nextResolve; });
+  return { promise, resolve };
+}
+
+vi.mock('webextension-polyfill', () => ({
+  default: { storage: { session: mocks } },
+}));
+
+vi.mock('@/shared/logging/logger.js', () => ({
+  getScopedLogger: () => ({ warn: vi.fn() }),
+}));
+
+describe('translationUiSessionState', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    browser.storage.session = mocks;
+    mocks.get.mockReset().mockResolvedValue({});
+    mocks.set.mockReset().mockResolvedValue(undefined);
+    mocks.remove.mockReset().mockResolvedValue(undefined);
+  });
+
+  it('isolates popup and sidepanel keys', async () => {
+    await translationUiSessionState.save('popup', { revision: 1, draftSource: 'popup' });
+    await translationUiSessionState.save('sidepanel', { revision: 1, draftSource: 'sidepanel' });
+
+    expect(mocks.set).toHaveBeenCalledWith({ 'translation-ui-session:popup': expect.any(Object) });
+    expect(mocks.set).toHaveBeenCalledWith({ 'translation-ui-session:sidepanel': expect.any(Object) });
+  });
+
+  it('loads and clears only requested context', async () => {
+    mocks.get.mockResolvedValue({ 'translation-ui-session:popup': { draftSource: 'draft' } });
+
+    await expect(translationUiSessionState.load('popup')).resolves.toEqual({ draftSource: 'draft' });
+    await translationUiSessionState.clear('popup', 2);
+
+    expect(mocks.get).toHaveBeenCalledWith('translation-ui-session:popup');
+    expect(mocks.remove).toHaveBeenCalledWith('translation-ui-session:popup');
+  });
+
+  it('rejects an older revision after a newer snapshot was accepted', async () => {
+    await translationUiSessionState.save('sidepanel', { revision: 10, draftSource: 'new' });
+    await expect(translationUiSessionState.save('sidepanel', { revision: 9, draftSource: 'old' })).resolves.toBe(false);
+
+    expect(mocks.set).toHaveBeenCalledTimes(1);
+    expect(mocks.set).toHaveBeenCalledWith({
+      'translation-ui-session:sidepanel': expect.objectContaining({ draftSource: 'new' }),
+    });
+  });
+
+  it('seeds revision protection from a loaded snapshot', async () => {
+    mocks.get.mockResolvedValue({ 'translation-ui-session:popup': { revision: 10 } });
+
+    await translationUiSessionState.load('popup');
+    await expect(translationUiSessionState.save('popup', { revision: 9 })).resolves.toBe(false);
+
+    expect(mocks.set).not.toHaveBeenCalled();
+  });
+
+  it('rejects a stale clear without removing newer state', async () => {
+    await translationUiSessionState.save('sidepanel', { revision: 20, draftSource: 'new' });
+
+    await expect(translationUiSessionState.clear('sidepanel', 19)).resolves.toBe(false);
+
+    expect(mocks.remove).not.toHaveBeenCalled();
+  });
+
+  it('skips a queued clear superseded by a newer revision', async () => {
+    const firstSave = deferred();
+    mocks.set
+      .mockImplementationOnce(() => firstSave.promise)
+      .mockResolvedValueOnce(undefined);
+
+    const initial = translationUiSessionState.save('popup', { revision: 20, draftSource: 'old' });
+    await Promise.resolve();
+    const staleClear = translationUiSessionState.clear('popup', 20);
+    const newer = translationUiSessionState.save('popup', { revision: 21, draftSource: 'new' });
+    firstSave.resolve();
+
+    await expect(initial).resolves.toBe(false);
+    await expect(staleClear).resolves.toBe(false);
+    await expect(newer).resolves.toBe(true);
+    expect(mocks.remove).not.toHaveBeenCalled();
+    expect(mocks.set).toHaveBeenLastCalledWith({
+      'translation-ui-session:popup': expect.objectContaining({ revision: 21, draftSource: 'new' }),
+    });
+  });
+
+  it('fails safely without session storage or local fallback', async () => {
+    browser.storage.session = undefined;
+
+    await expect(translationUiSessionState.load('popup')).resolves.toBeNull();
+    await expect(translationUiSessionState.save('popup', { revision: 1 })).resolves.toBe(false);
+    await expect(translationUiSessionState.clear('popup', 1)).resolves.toBe(false);
+
+    expect(mocks.get).not.toHaveBeenCalled();
+    expect(mocks.set).not.toHaveBeenCalled();
+    expect(mocks.remove).not.toHaveBeenCalled();
+  });
+
+  it('swallows write failures without a durable fallback', async () => {
+    mocks.set.mockRejectedValue(new Error('quota'));
+
+    await expect(translationUiSessionState.save('popup', { revision: 30 })).resolves.toBe(false);
+
+    expect(mocks.set).toHaveBeenCalledTimes(1);
+    expect(browser.storage.local).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

Preserves translation UI state across Popup and Sidepanel close/reopen events during the same browser session.

Popup and Sidepanel state remain fully isolated.

## Changes

* Added session-only persistence using `browser.storage.session`.
* Added separate session state for Popup and Sidepanel.
* Restores source text, translation result, languages, and provider.
* Prevents stale translation results after source edits.
* Handles streaming, cancellation, failure, clear, and revert correctly.
* Consolidated Popup to a single `useUnifiedTranslation` owner.
* Added revision protection against stale session writes.
* Keeps same-language translation metadata semantically correct.
* No durable/local-storage fallback.

## Validation

* 42 focused tests passed.
* ESLint passed.
* `git diff --check` passed.
* Chrome production build passed.
* Firefox production build passed.
