### PR TITLE
Fix Microsoft Edge translation provider

### DIFF
--- a/src/features/settings/stores/settings.js
+++ b/src/features/settings/stores/settings.js
@@ -399,10 +399,11 @@ export const useSettingsStore = defineStore('settings', () => {
 
       // 2. Run the centralized migration logic on the imported data
       // This handles MODE_PROVIDERS (underscore to hyphen), API_KEY, etc.
-      const { updates, logs } = await runSettingsMigrations(mergedSettings);
+      const { updates, logs, removals = [] } = await runSettingsMigrations(mergedSettings);
 
       // 3. Apply all migrated updates to our final settings object
       Object.assign(mergedSettings, updates);
+      removals.forEach(key => delete mergedSettings[key]);
       
       if (logs && logs.length > 0) {
         logger.info('[Import] Migrations applied:', logs);

--- a/src/features/settings/stores/settings.test.js
+++ b/src/features/settings/stores/settings.test.js
@@ -232,6 +232,25 @@ describe('Settings Store', () => {
       expect(storageManager.set).toHaveBeenCalled();
     });
 
+    it('importSettings should remove obsolete endpoint overrides returned by migrations', async () => {
+      secureStorage.processImportedSettings.mockResolvedValueOnce({
+        THEME: 'dark',
+        MICROSOFT_EDGE_AUTH_URL: 'https://edge.microsoft.com/translate/auth',
+        MICROSOFT_EDGE_TRANSLATE_URL: 'https://api-edge.cognitive.microsofttranslator.com/translate'
+      });
+      runSettingsMigrations.mockResolvedValueOnce({
+        updates: {},
+        removals: ['MICROSOFT_EDGE_AUTH_URL', 'MICROSOFT_EDGE_TRANSLATE_URL'],
+        logs: []
+      });
+
+      const store = useSettingsStore();
+      await store.importSettings({ THEME: 'dark', _exported: true });
+
+      expect(store.settings).not.toHaveProperty('MICROSOFT_EDGE_AUTH_URL');
+      expect(store.settings).not.toHaveProperty('MICROSOFT_EDGE_TRANSLATE_URL');
+    });
+
     it('importSettings should pass legacy Mouse Hover triggers through centralized migration', async () => {
       secureStorage.processImportedSettings.mockResolvedValueOnce({
         THEME: 'dark',

--- a/src/features/translation/providers/MicrosoftEdgeProvider.js
+++ b/src/features/translation/providers/MicrosoftEdgeProvider.js
@@ -5,17 +5,14 @@ import { ProviderNames } from "@/features/translation/providers/ProviderConstant
 import { getTextInfo } from "./utils/TraditionalTextProcessor.js";
 import { getProviderLanguageCode } from "@/shared/config/languageConstants.js";
 import { AUTO_DETECT_VALUE } from "@/shared/constants/core.js";
-import { 
-  getMicrosoftEdgeAuthUrlAsync,
-  getMicrosoftEdgeTranslateUrlAsync
-} from "@/shared/config/config.js";
+import { CONFIG } from "@/shared/config/config.js";
 import { ErrorTypes } from "@/shared/error-management/ErrorTypes.js";
 
 const logger = getScopedLogger(LOG_COMPONENTS.PROVIDERS, 'MicrosoftEdge');
 
 /**
  * Microsoft Edge Translation Provider
- * Uses the internal Edge translation API endpoints
+ * Uses the current unauthenticated Edge translation API endpoint
  * 
  * Source Reference:
  * https://github.com/translate-tools/core/blob/master/src/translators/MicrosoftTranslator/index.ts
@@ -25,9 +22,6 @@ export class MicrosoftEdgeProvider extends BaseTranslateProvider {
   static displayName = "Microsoft Edge";
   static reliableJsonMode = true;
   
-  static accessToken = null;
-  static tokenExpiry = 0;
-
   constructor() {
     super(ProviderNames.MICROSOFT_EDGE);
   }
@@ -52,67 +46,6 @@ export class MicrosoftEdgeProvider extends BaseTranslateProvider {
   }
 
   /**
-   * Fetch Microsoft Edge auth token with caching and expiry management
-   * @param {AbortController} abortController - Controller for cancellation
-   * @returns {Promise<string>} - Auth token
-   */
-  async _getAuthToken(abortController) {
-    // Return cached token if still valid (with 30s buffer)
-    if (MicrosoftEdgeProvider.accessToken && MicrosoftEdgeProvider.tokenExpiry > Date.now() + 30000) {
-      return MicrosoftEdgeProvider.accessToken;
-    }
-
-    logger.debug('[Edge] Fetching new auth token...');
-    
-    const authUrl = await getMicrosoftEdgeAuthUrlAsync();
-
-    return this._executeRequest({
-      url: authUrl,
-      fetchOptions: {
-        method: 'GET',
-        mode: 'cors',
-        credentials: 'omit',
-        headers: {
-          'Accept': '*/*',
-          'Accept-Language': 'zh-TW,zh;q=0.9,ja;q=0.8,zh-CN;q=0.7,en-US;q=0.6,en;q=0.5',
-          'Cache-Control': 'no-cache',
-          'Pragma': 'no-cache',
-          'Priority': 'u=1, i',
-          'Sec-Fetch-Dest': 'empty',
-          'Sec-Fetch-Mode': 'cors',
-          'Sec-Fetch-Site': 'none',
-          'Sec-Fetch-Storage-Access': 'active'
-        }
-      },
-      extractResponse: async (response) => {
-        const token = await response.text();
-        if (!token) {
-          const err = new Error("Received empty token from Edge auth");
-          err.type = ErrorTypes.API_KEY_MISSING;
-          throw err;
-        }
-
-        // Decode JWT to get expiry
-        MicrosoftEdgeProvider.accessToken = token;
-        
-        try {
-          const payload = JSON.parse(atob(token.split('.')[1]));
-          MicrosoftEdgeProvider.tokenExpiry = payload.exp * 1000;
-        } catch {
-          // Fallback to 30 second lifetime as seen in anylang
-          MicrosoftEdgeProvider.tokenExpiry = Date.now() + (30 * 1000);
-        }
-
-        logger.debug('[Edge] Auth token obtained successfully');
-        return token;
-      },
-      context: 'edge-auth',
-      abortController,
-      charCount: 0 // Explicitly set to 0 to avoid using carrier charCount
-    });
-  }
-
-  /**
    * Implement translation for a single chunk
    * @param {string[]} chunkTexts - Texts in this chunk
    * @param {string} sourceLang - Source language
@@ -125,14 +58,12 @@ export class MicrosoftEdgeProvider extends BaseTranslateProvider {
    * @param {number} totalChunks - Total number of chunks
    * @param {Object} options - Additional options (sessionId, originalCharCount)
    * @returns {Promise<string[]>} - Translated texts for this chunk
-   */
+  */
   async _translateChunk(chunkTexts, sourceLang, targetLang, translateMode, abortController, retryAttempt, segmentCount, chunkIndex, totalChunks, options = {}) {
-    const token = await this._getAuthToken(abortController);
-    
     const sl = this._getLangCode(sourceLang);
     const tl = this._getLangCode(targetLang) || 'fa';
 
-    const translateUrl = await getMicrosoftEdgeTranslateUrlAsync();
+    const translateUrl = CONFIG.MICROSOFT_EDGE_TRANSLATE_URL;
     
     /**
      * Internal helper to execute the request with a specific source language
@@ -140,7 +71,7 @@ export class MicrosoftEdgeProvider extends BaseTranslateProvider {
      */
     const performRequest = async (currentSource) => {
       const url = new URL(translateUrl);
-      url.searchParams.set("api-version", "3.0");
+      url.searchParams.set("isEnterpriseClient", "false");
       
       // CRITICAL: Omit 'from' parameter completely for auto-detection or if rejected.
       if (currentSource && currentSource !== "auto-detect") {
@@ -148,32 +79,41 @@ export class MicrosoftEdgeProvider extends BaseTranslateProvider {
       }
       
       url.searchParams.set("to", tl);
-      url.searchParams.set("includeSentenceLength", "true");
 
-      // Microsoft Edge expects array of objects: [{ "Text": "..." }, ...]
+      // Microsoft Edge expects an array of text strings: ["...", "..."]
       // We use getTextInfo to extract text from objects (Subtitle cues, Select Element)
-      const body = chunkTexts.map(item => ({ Text: getTextInfo(item).text }));
+      const body = chunkTexts.map(item => getTextInfo(item).text);
 
       return await this._executeRequest({
         url: url.toString(),
         fetchOptions: {
           method: "POST",
           mode: 'cors',
-          credentials: 'include',
+          credentials: 'omit',
           headers: {
-            "Authorization": `Bearer ${token}`,
-            "Content-Type": "application/json",
-            "Accept": "*/*",
-            "Cache-Control": "no-cache",
-            "Pragma": "no-cache",
-            "Priority": "u=1, i"
+            "Content-Type": "application/json"
           },
           body: JSON.stringify(body)
         },
-        extractResponse: (data) => {
+        extractResponse: (data, statusCode) => {
+          let parsed = data;
+
+          if (typeof data === 'string') {
+            try {
+              parsed = JSON.parse(data);
+            } catch {
+              const error = new Error('Provider response contains invalid JSON');
+              error.type = ErrorTypes.JSON_PARSING_ERROR;
+              error.statusCode = statusCode;
+              error.context = 'edge-translate-chunk';
+              error.providerName = this.providerName;
+              throw error;
+            }
+          }
+
           // No silent empty-fill: a malformed response must fail loudly so the
           // caller never mistakes empty strings for a successful translation.
-          if (!data?.[0]?.translations) {
+          if (!parsed?.[0]?.translations) {
             logger.error('[Edge] Unexpected API response format');
             const err = new Error(ErrorTypes.API_RESPONSE_INVALID);
             err.type = ErrorTypes.API_RESPONSE_INVALID;
@@ -181,7 +121,7 @@ export class MicrosoftEdgeProvider extends BaseTranslateProvider {
           }
           
           // Match anylang logic: Join multiple translation segments if present
-          const translatedTexts = data.map(item => {
+          const translatedTexts = parsed.map(item => {
             if (!item.translations || !Array.isArray(item.translations)) {
               const err = new Error(ErrorTypes.API_RESPONSE_INVALID);
               err.type = ErrorTypes.API_RESPONSE_INVALID;
@@ -200,7 +140,7 @@ export class MicrosoftEdgeProvider extends BaseTranslateProvider {
             return joinedText;
           });
 
-          this._setExecutionDetectedLanguage(options, data[0].detectedLanguage?.language);
+          this._setExecutionDetectedLanguage(options, parsed[0].detectedLanguage?.language);
           return translatedTexts;
         },
         context: 'edge-translate-chunk',

--- a/src/features/translation/providers/MicrosoftEdgeProvider.test.js
+++ b/src/features/translation/providers/MicrosoftEdgeProvider.test.js
@@ -24,8 +24,14 @@ vi.mock('@/shared/logging/logger.js', () => ({
 }));
 
 vi.mock("@/shared/config/config.js", () => ({
-  getMicrosoftEdgeAuthUrlAsync: vi.fn().mockResolvedValue('https://auth.edge.com'),
-  getMicrosoftEdgeTranslateUrlAsync: vi.fn().mockResolvedValue('https://api.edge.com/translate'),
+  CONFIG: {
+    MICROSOFT_EDGE_TRANSLATE_URL: 'https://edge.microsoft.com/translate/translatetext'
+  },
+  TranslationMode: {
+    Page: 'page-translation-batch',
+    Select_Element: 'select-element',
+    PDF: 'pdf-translation'
+  },
   getProviderOptimizationLevelAsync: vi.fn(() => Promise.resolve('balanced')),
 }));
 
@@ -63,9 +69,11 @@ describe('MicrosoftEdgeProvider', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     provider = new MicrosoftEdgeProvider();
-    MicrosoftEdgeProvider.accessToken = null;
-    MicrosoftEdgeProvider.tokenExpiry = 0;
   });
+
+  const mockResponse = (providerInstance, response, statusCode = 200) => vi
+    .spyOn(providerInstance, '_executeRequest')
+    .mockImplementation(async (options) => options.extractResponse(response, statusCode));
 
   describe('_getLangCode', () => {
     it('should return null for auto-detect', () => {
@@ -77,57 +85,98 @@ describe('MicrosoftEdgeProvider', () => {
     });
   });
 
-  describe('_getAuthToken', () => {
-    it('should fetch and process a new token', async () => {
-      const mockToken = 'header.eyJleHAiOjE3Nzc1MDUzNzZ9.signature'; // Payload with exp
-      
-      // We need to simulate _executeRequest calling the extractResponse callback
-      vi.spyOn(provider, '_executeRequest').mockImplementation(async (opts) => {
-        const mockResponse = { text: () => Promise.resolve(mockToken) };
-        return await opts.extractResponse(mockResponse);
-      });
-
-      const token = await provider._getAuthToken();
-
-      expect(token).toBe(mockToken);
-      expect(MicrosoftEdgeProvider.accessToken).toBe(mockToken);
-      expect(MicrosoftEdgeProvider.tokenExpiry).toBeGreaterThan(0);
-    });
-  });
-
   describe('_translateChunk', () => {
-    it('should translate text and detect language', async () => {
-      vi.spyOn(provider, '_getAuthToken').mockResolvedValue('valid-token');
-      
-      const mockApiResponse = [
-        { translations: [{ text: 'سلام' }], detectedLanguage: { language: 'en' } }
-      ];
-      
-      // Simulate _executeRequest returning the extracted data
-      vi.spyOn(provider, '_executeRequest').mockImplementation(async (opts) => {
-        return opts.extractResponse(mockApiResponse);
-      });
-
+    it('should send the current Edge request contract for explicit source language', async () => {
+      const executeMock = mockResponse(provider, '[{"translations":[{"text":"سلام"}]}]');
       const options = { providerMetadataRef: { metadata: {} } };
-      const result = await provider._translateChunk(['Hello'], 'en', 'fa', 'selection', null, 0, 1, 0, 1, options);
 
-      expect(result).toEqual(['سلام']);
+      await expect(provider._translateChunk(
+        ['Hello'], 'en', 'fa', 'selection', null, 0, 1, 0, 1, options
+      )).resolves.toEqual(['سلام']);
+
+      const request = executeMock.mock.calls[0][0];
+      const requestUrl = new URL(request.url);
+      expect(`${requestUrl.origin}${requestUrl.pathname}`).toBe(
+        'https://edge.microsoft.com/translate/translatetext'
+      );
+      expect(requestUrl.searchParams.get('isEnterpriseClient')).toBe('false');
+      expect(requestUrl.searchParams.get('to')).toBe('fa');
+      expect(requestUrl.searchParams.get('from')).toBe('en');
+      expect(requestUrl.searchParams.has('api-version')).toBe(false);
+      expect(requestUrl.searchParams.has('includeSentenceLength')).toBe(false);
+      expect(request.fetchOptions.method).toBe('POST');
+      expect(request.fetchOptions.credentials).toBe('omit');
+      expect(request.fetchOptions.headers).toEqual({ 'Content-Type': 'application/json' });
+      expect(request.fetchOptions.headers).not.toHaveProperty('Authorization');
+      expect(JSON.parse(request.fetchOptions.body)).toEqual(['Hello']);
+    });
+
+    it('should omit from for auto-detect and send multiple text strings', async () => {
+      const executeMock = mockResponse(provider, [
+        { translations: [{ text: 'سلام' }] },
+        { translations: [{ text: 'دنیا' }] }
+      ]);
+
+      await expect(provider._translateChunk(
+        ['Hello', 'World'], 'auto', 'fa', 'selection', null
+      )).resolves.toEqual(['سلام', 'دنیا']);
+
+      const request = executeMock.mock.calls[0][0];
+      const requestUrl = new URL(request.url);
+      expect(requestUrl.searchParams.get('isEnterpriseClient')).toBe('false');
+      expect(requestUrl.searchParams.get('to')).toBe('fa');
+      expect(requestUrl.searchParams.has('from')).toBe(false);
+      expect(JSON.parse(request.fetchOptions.body)).toEqual(['Hello', 'World']);
+    });
+
+    it('should publish detected language metadata when provided', async () => {
+      mockResponse(
+        provider,
+        '[{"translations":[{"text":"سلام"}],"detectedLanguage":{"language":"EN"}}]'
+      );
+      const options = { providerMetadataRef: { metadata: {} } };
+
+      await provider._translateChunk(['Hello'], 'en', 'fa', 'selection', null, 0, 1, 0, 1, options);
+
       expect(options.providerMetadataRef.metadata.detectedLanguage).toBe('en');
-      expect(provider).not.toHaveProperty('lastDetectedLanguage');
+    });
+
+    it('should throw JSON_PARSING_ERROR for invalid raw JSON', async () => {
+      mockResponse(provider, 'not-json');
+
+      await expect(provider._translateChunk(['Hello'], 'en', 'fa', 'selection', null))
+        .rejects.toMatchObject({
+          type: 'JSON_PARSING_ERROR',
+          statusCode: 200,
+          context: 'edge-translate-chunk'
+        });
+    });
+
+    it('should not invent detected language metadata when it is absent', async () => {
+      mockResponse(provider, [{ translations: [{ text: 'سلام' }] }]);
+      const options = { providerMetadataRef: { metadata: {} } };
+
+      await provider._translateChunk(['Hello'], 'en', 'fa', 'selection', null, 0, 1, 0, 1, options);
+
+      expect(options.providerMetadataRef.metadata).toEqual({});
+    });
+
+    it('should preserve existing metadata when detected language is absent', async () => {
+      mockResponse(provider, [{ translations: [{ text: 'سلام' }] }]);
+      const options = { providerMetadataRef: { metadata: { detectedLanguage: 'fr' } } };
+
+      await provider._translateChunk(['Hello'], 'en', 'fa', 'selection', null, 0, 1, 0, 1, options);
+
+      expect(options.providerMetadataRef.metadata.detectedLanguage).toBe('fr');
     });
 
     it('should throw API_RESPONSE_INVALID for malformed API response', async () => {
-      vi.spyOn(provider, '_getAuthToken').mockResolvedValue('valid-token');
-
-      const malformedResponse = { unexpected: 'shape' };
-
-      vi.spyOn(provider, '_executeRequest').mockImplementation(async (opts) => {
-        return opts.extractResponse(malformedResponse);
-      });
-
+      mockResponse(provider, { unexpected: 'shape' });
       const options = { providerMetadataRef: { metadata: {} } };
-      await expect(provider._translateChunk(['Hello'], 'en', 'fa', 'selection', null, 0, 1, 0, 1, options))
-        .rejects.toMatchObject({ type: 'API_RESPONSE_INVALID' });
+
+      await expect(provider._translateChunk(
+        ['Hello'], 'en', 'fa', 'selection', null, 0, 1, 0, 1, options
+      )).rejects.toMatchObject({ type: 'API_RESPONSE_INVALID' });
       expect(options.providerMetadataRef.metadata).toEqual({});
     });
 
@@ -136,64 +185,43 @@ describe('MicrosoftEdgeProvider', () => {
       ['empty translated text', [{ translations: [{ text: '' }] }]],
       ['whitespace-only translated text', [{ translations: [{ text: '   ' }] }]],
     ])('throws API_RESPONSE_INVALID for %s instead of returning empty output', async (_label, response) => {
-      vi.spyOn(provider, '_getAuthToken').mockResolvedValue('valid-token');
-
-      vi.spyOn(provider, '_executeRequest').mockImplementation(async (opts) => {
-        return opts.extractResponse(response);
-      });
+      mockResponse(provider, response);
 
       await expect(provider._translateChunk(['Hello'], 'en', 'fa', 'selection', null))
         .rejects.toMatchObject({ type: 'API_RESPONSE_INVALID' });
     });
 
     it('accepts identity translation where translated text equals source', async () => {
-      vi.spyOn(provider, '_getAuthToken').mockResolvedValue('valid-token');
+      mockResponse(provider, [{ translations: [{ text: 'URL' }] }]);
 
-      const identityResponse = [{ translations: [{ text: 'URL' }] }];
-
-      vi.spyOn(provider, '_executeRequest').mockImplementation(async (opts) => {
-        return opts.extractResponse(identityResponse);
-      });
-
-      await expect(provider._translateChunk(['URL'], 'en', 'fa', 'selection', null)).resolves.toEqual(['URL']);
+      await expect(provider._translateChunk(['URL'], 'en', 'fa', 'selection', null))
+        .resolves.toEqual(['URL']);
     });
 
     it('should throw API_RESPONSE_INVALID when a translation item lacks translations', async () => {
-      vi.spyOn(provider, '_getAuthToken').mockResolvedValue('valid-token');
-
-      const malformedResponse = [
+      mockResponse(provider, [
         { translations: [{ text: 'سلام' }] },
         { missing: 'translations field' }
-      ];
-
-      vi.spyOn(provider, '_executeRequest').mockImplementation(async (opts) => {
-        return opts.extractResponse(malformedResponse);
-      });
+      ]);
 
       await expect(provider._translateChunk(['Hello', 'World'], 'en', 'fa', 'selection', null))
         .rejects.toMatchObject({ type: 'API_RESPONSE_INVALID' });
     });
 
-    it('should retry without "from" param if source language is rejected', async () => {
-      vi.spyOn(provider, '_getAuthToken').mockResolvedValue('valid-token');
-      
+    it('should retry without from when source language is rejected', async () => {
       const executeMock = vi.spyOn(provider, '_executeRequest');
-      const langError = new Error('The source language is not valid');
-      
       executeMock
-        .mockRejectedValueOnce(langError)
-        .mockImplementationOnce(async (opts) => {
-          return opts.extractResponse([{ translations: [{ text: 'سلام' }] }]);
-        });
+        .mockRejectedValueOnce(new Error('The source language is not valid'))
+        .mockImplementationOnce(async (options) => options.extractResponse([
+          { translations: [{ text: 'سلام' }] }
+        ]));
 
       const result = await provider._translateChunk(['Hello'], 'invalid-lang', 'fa', 'selection', null);
 
       expect(result).toEqual(['سلام']);
       expect(executeMock).toHaveBeenCalledTimes(2);
-      
-      // Verify retry URL doesn't have 'from'
-      const secondCallUrl = new URL(executeMock.mock.calls[1][0].url);
-      expect(secondCallUrl.searchParams.has('from')).toBe(false);
+      expect(new URL(executeMock.mock.calls[0][0].url).searchParams.get('from')).toBe('invalid-lang');
+      expect(new URL(executeMock.mock.calls[1][0].url).searchParams.has('from')).toBe(false);
     });
   });
 });

--- a/src/shared/config/config.js
+++ b/src/shared/config/config.js
@@ -175,8 +175,7 @@ export const CONFIG = {
   DEEPL_PRO_API_URL: "https://api.deepl.com/v2/translate",
   YANDEX_TRANSLATE_URL: "https://translate.yandex.net/api/v1/tr.json/translate",
   YANDEX_DETECT_URL: "https://translate.yandex.net/api/v1/tr.json/detect",
-  MICROSOFT_EDGE_AUTH_URL: "https://edge.microsoft.com/translate/auth",
-  MICROSOFT_EDGE_TRANSLATE_URL: "https://api-edge.cognitive.microsofttranslator.com/translate",
+  MICROSOFT_EDGE_TRANSLATE_URL: "https://edge.microsoft.com/translate/translatetext",
   LINGVA_API_URL: "",
   WEBAI_API_URL: "",
   WEBAI_API_MODEL: "gemini-3-flash",
@@ -833,15 +832,6 @@ export const getYandexTranslateUrlAsync = async () => {
 
 export const getYandexDetectUrlAsync = async () => {
   return getSettingValueAsync("YANDEX_DETECT_URL", CONFIG.YANDEX_DETECT_URL);
-};
-
-// Microsoft Edge Specific
-export const getMicrosoftEdgeAuthUrlAsync = async () => {
-  return getSettingValueAsync("MICROSOFT_EDGE_AUTH_URL", CONFIG.MICROSOFT_EDGE_AUTH_URL);
-};
-
-export const getMicrosoftEdgeTranslateUrlAsync = async () => {
-  return getSettingValueAsync("MICROSOFT_EDGE_TRANSLATE_URL", CONFIG.MICROSOFT_EDGE_TRANSLATE_URL);
 };
 
 // Lingva Translate Specific

--- a/src/shared/config/config.test.js
+++ b/src/shared/config/config.test.js
@@ -70,6 +70,13 @@ describe('Config Module', () => {
       expect(CONFIG.APP_NAME).toBe('Translate It');
     });
 
+    it('should expose the current Microsoft Edge translation endpoint without auth config', () => {
+      expect(CONFIG.MICROSOFT_EDGE_TRANSLATE_URL).toBe(
+        'https://edge.microsoft.com/translate/translatetext'
+      );
+      expect(CONFIG).not.toHaveProperty('MICROSOFT_EDGE_AUTH_URL');
+    });
+
     it('should expose approved WebAI models in order', () => {
       expect(CONFIG.WEBAI_API_MODEL).toBe('gemini-3-flash');
       expect(CONFIG.WEBAI_API_URL).toBe('');

--- a/src/shared/config/settingsMigrations.js
+++ b/src/shared/config/settingsMigrations.js
@@ -49,6 +49,11 @@ const MODEL_VALUE_MIGRATIONS = {
   }
 };
 
+const OBSOLETE_MICROSOFT_EDGE_SETTING_KEYS = [
+  'MICROSOFT_EDGE_AUTH_URL',
+  'MICROSOFT_EDGE_TRANSLATE_URL'
+];
+
 /**
  * Migrate the former ambiguous Ctrl trigger to the platform-aware primary modifier.
  */
@@ -57,6 +62,19 @@ function migrateMouseHoverTrigger(currentSettings, updates, migrationLog) {
 
   updates.MOUSE_HOVER_TRIGGER = 'primary';
   migrationLog.push('Migrated MOUSE_HOVER_TRIGGER from ctrl to primary');
+}
+
+/**
+ * Remove internal Microsoft Edge endpoint overrides from older installations.
+ * The provider now owns one canonical endpoint and exposes no custom endpoint setting.
+ */
+function removeObsoleteMicrosoftEdgeSettings(currentSettings, removals, migrationLog) {
+  OBSOLETE_MICROSOFT_EDGE_SETTING_KEYS.forEach(key => {
+    if (!Object.prototype.hasOwnProperty.call(currentSettings, key)) return;
+
+    removals.push(key);
+    migrationLog.push(`Removed obsolete setting: ${key}`);
+  });
 }
 
 /**
@@ -307,6 +325,8 @@ function runMainMigration(currentSettings) {
       migrationLog.push(`Removing obsolete stored prompt wrapper: ${key}`);
     });
   }
+
+  removeObsoleteMicrosoftEdgeSettings(currentSettings, removals, migrationLog);
   if (Object.prototype.hasOwnProperty.call(currentSettings, 'GEMINI_THINKING_ENABLED')) {
     removals.push('GEMINI_THINKING_ENABLED');
     migrationLog.push('Removing obsolete stored setting: GEMINI_THINKING_ENABLED');

--- a/src/shared/config/settingsMigrations.test.js
+++ b/src/shared/config/settingsMigrations.test.js
@@ -32,6 +32,20 @@ describe('Settings Migrations', () => {
     expect(updates.CHANGELOG_URL).toBeUndefined();
   });
 
+  it('should remove obsolete Microsoft Edge endpoint overrides', async () => {
+    const { removals, logs } = await runSettingsMigrations({
+      MICROSOFT_EDGE_AUTH_URL: 'https://edge.microsoft.com/translate/auth',
+      MICROSOFT_EDGE_TRANSLATE_URL: 'https://api-edge.cognitive.microsofttranslator.com/translate'
+    });
+
+    expect(removals).toEqual(expect.arrayContaining([
+      'MICROSOFT_EDGE_AUTH_URL',
+      'MICROSOFT_EDGE_TRANSLATE_URL'
+    ]));
+    expect(logs).toContain('Removed obsolete setting: MICROSOFT_EDGE_AUTH_URL');
+    expect(logs).toContain('Removed obsolete setting: MICROSOFT_EDGE_TRANSLATE_URL');
+  });
+
   it('should migrate the legacy Mouse Hover ctrl trigger to primary', async () => {
     const { updates, logs } = await runSettingsMigrations({
       MOUSE_HOVER_TRIGGER: 'ctrl'


### PR DESCRIPTION
## Summary

Fixes Microsoft Edge translation after the legacy auth endpoint started returning `404`.

## Changes

* Switched to the current Edge translation endpoint.
* Removed the obsolete auth/JWT flow.
* Updated request format for the new API contract.
* Added support for raw JSON string responses.
* Removed obsolete Edge endpoint settings and migrations.
* Preserved language mapping, auto-detection, validation, and fallback behavior.
* Added and updated provider/config/migration tests.

## Validation

* Edge provider tests passed.
* Affected test suite passed.
* ESLint passed.
* `git diff --check` passed.
* Firefox production build passed.
* Firefox UI smoke test passed with `Test → تست`.
