### PR TITLE
Improve context menu behavior and shortcut navigation

### DIFF
--- a/scripts/localization/check-i18n.cjs
+++ b/scripts/localization/check-i18n.cjs
@@ -38,7 +38,8 @@ const safeSpecificKeys = [
   'app_welcome', 'context_menu_options', 'context_menu_shortcuts', 
   'context_menu_help', 'context_menu_translate_screen', 
   'context_menu_reload_extension', 'context_menu_translate_with_selection', 
-  'context_menu_api_provider', 'export_settings_description', 
+  'context_menu_api_provider', 'context_menu_translators', 'context_menu_settings',
+  'export_settings_description', 
   'import_settings_description', 'import_success', 
   'notification_update_title', 'notification_update_message', 
   'save_settings_button', 'excluded_sites_label', 'translateSelectedText'

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -47,6 +47,12 @@
   "context_menu_api_provider": {
     "message": "API Provider"
   },
+  "context_menu_translators": {
+    "message": "Translators"
+  },
+  "context_menu_settings": {
+    "message": "Settings"
+  },
   "api_provider_google": {
     "message": "Google Translate (Classic)"
   },

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -594,19 +594,19 @@
     "message": "How to change keyboard shortcuts ?"
   },
   "help_shortcut_content_p1": {
-    "message": "In Firefox, shortcuts are managed through the Add-ons page:"
+    "message": "To customize keyboard shortcuts:"
   },
   "help_shortcut_content_li1": {
-    "message": "Navigate to **about:addons** in your address bar."
+    "message": "Right-click the **Translate It** icon in the browser toolbar."
   },
   "help_shortcut_content_li2": {
-    "message": "Click the **gear icon (⚙️)** in the top-right corner."
+    "message": "Open **Settings**."
   },
   "help_shortcut_content_li3": {
-    "message": "Select **Manage Extension Shortcuts** from the menu."
+    "message": "Select **Keyboard Shortcut**."
   },
   "help_shortcut_content_li4": {
-    "message": "Find **Translate It** and set your desired shortcut."
+    "message": "Your browser's shortcut settings page will open."
   },
   "help_api_keys_title": {
     "message": "Where do I get API keys?"
@@ -648,16 +648,7 @@
     "message": "Your API keys are stored locally in your browser and are never shared with third parties. For additional security, you can encrypt your settings when exporting them using the Import/Export feature."
   },
   "help_shortcut_content_p2": {
-    "message": "In **Chrome**, the process is different:"
-  },
-  "help_shortcut_content_chrome_li1": {
-    "message": "Right-click on the extension icon."
-  },
-  "help_shortcut_content_chrome_li2": {
-    "message": "Select **Keyboard shortcuts** from the menu."
-  },
-  "help_shortcut_content_chrome_li3": {
-    "message": "Click the pencil icon (✏️) next to **Translate It** and type your new shortcut."
+    "message": "Find **Translate It** and configure the shortcuts you want."
   },
   "translation_activation_section_title": {
     "message": "Translation Activation Methods"

--- a/src/_locales/fa/messages.json
+++ b/src/_locales/fa/messages.json
@@ -47,6 +47,12 @@
   "context_menu_api_provider": {
     "message": "سرور API"
   },
+  "context_menu_translators": {
+    "message": "مترجم‌ها"
+  },
+  "context_menu_settings": {
+    "message": "تنظیمات"
+  },
   "api_provider_google": {
     "message": "مترجم گوگل (کلاسیک)"
   },

--- a/src/_locales/fa/messages.json
+++ b/src/_locales/fa/messages.json
@@ -594,19 +594,19 @@
     "message": "چگونه میانبرهای کیبورد را تغییر دهیم؟"
   },
   "help_shortcut_content_p1": {
-    "message": "در **Firefox**، میانبرها از طریق صفحه افزونه‌ها مدیریت می‌شوند:"
+    "message": "برای سفارشی‌سازی میانبرهای کیبورد:"
   },
   "help_shortcut_content_li1": {
-    "message": "آدرس <strong>about:addons</strong> را در نوار آدرس خود وارد کنید."
+    "message": "روی آیکون **Translate It** در نوار ابزار مرورگر کلیک راست کنید."
   },
   "help_shortcut_content_li2": {
-    "message": "روی آیکون **چرخ‌دنده (⚙️)** در گوشه بالا-راست کلیک کنید."
+    "message": "**تنظیمات** را باز کنید."
   },
   "help_shortcut_content_li3": {
-    "message": "گزینه **Manage Extension Shortcuts** را از منو انتخاب کنید."
+    "message": "**میانبر کیبورد** را انتخاب کنید."
   },
   "help_shortcut_content_li4": {
-    "message": "افزونه **Translate It** را پیدا کرده و میانبر دلخواه خود را تنظیم کنید."
+    "message": "صفحه تنظیمات میانبرهای مرورگر شما باز می‌شود."
   },
   "help_api_keys_title": {
     "message": "کلیدهای API را از کجا دریافت کنم؟"
@@ -648,16 +648,7 @@
     "message": "کلیدهای API شما به‌صورت محلی در مرورگر شما ذخیره می‌شوند و هرگز با اشخاص ثالث به اشتراک گذاشته نمی‌شوند. برای امنیت بیشتر، می‌توانید هنگام خروجی گرفتن از تنظیمات با استفاده از ویژگی پشتیبان گیری، آن‌ها را رمزگذاری کنید."
   },
   "help_shortcut_content_p2": {
-    "message": "در **Chrome**، روند متفاوت است:"
-  },
-  "help_shortcut_content_chrome_li1": {
-    "message": "روی ایکون افزونه کلیک راست کنید."
-  },
-  "help_shortcut_content_chrome_li2": {
-    "message": "گزینه **تنظیمات میانبرها** را انتخاب کنید."
-  },
-  "help_shortcut_content_chrome_li3": {
-    "message": "روی آیکون مداد (✏️) کنار **Translate It** کلیک کنید و میانبر جدید خود را تایپ کنید."
+    "message": "افزونه **Translate It** را پیدا کنید و میانبرهای دلخواهتان را تنظیم کنید."
   },
   "translation_activation_section_title": {
     "message": "روش‌های فعال‌سازی ترجمه"

--- a/src/_locales/ja/messages.json
+++ b/src/_locales/ja/messages.json
@@ -47,6 +47,12 @@
   "context_menu_api_provider": {
     "message": "APIプロバイダー"
   },
+  "context_menu_translators": {
+    "message": "翻訳ツール"
+  },
+  "context_menu_settings": {
+    "message": "設定"
+  },
   "api_provider_google": {
     "message": "Google Translate (Classic)"
   },

--- a/src/_locales/ja/messages.json
+++ b/src/_locales/ja/messages.json
@@ -516,19 +516,19 @@
     "message": "キーボードショートカットの変更方法"
   },
   "help_shortcut_content_p1": {
-    "message": "Firefoxでは、ショートカットはアドオンページで管理します："
+    "message": "キーボードショートカットをカスタマイズするには："
   },
   "help_shortcut_content_li1": {
-    "message": "アドレスバーに **about:addons** と入力します。"
+    "message": "ブラウザーのツールバーにある **Translate It** アイコンを右クリックします。"
   },
   "help_shortcut_content_li2": {
-    "message": "右上の **歯車アイコン（⚙️）** をクリックします。"
+    "message": "**設定** を開きます。"
   },
   "help_shortcut_content_li3": {
-    "message": "メニューから **拡張機能のショートカットを管理** を選択します。"
+    "message": "**キーボードショートカット**を選択します。"
   },
   "help_shortcut_content_li4": {
-    "message": "**Translate It** を見つけて、お好みのショートカットを設定します。"
+    "message": "ブラウザーのショートカット設定ページが開きます。"
   },
   "help_api_keys_title": {
     "message": "APIキーはどこで取得できますか？"
@@ -570,16 +570,7 @@
     "message": "API キーはブラウザ内にローカルに保存され、第三者と共有されることはありません。さらにセキュリティを高めるため、インポート/エクスポート機能を使用して設定をエクスポートする際に暗号化することが可能です。"
   },
   "help_shortcut_content_p2": {
-    "message": "**Chrome** では操作が異なります："
-  },
-  "help_shortcut_content_chrome_li1": {
-    "message": "拡張機能アイコンを右クリックします。"
-  },
-  "help_shortcut_content_chrome_li2": {
-    "message": "メニューから **キーボードショートカット** を選択します。"
-  },
-  "help_shortcut_content_chrome_li3": {
-    "message": "**Translate It** の横にある鉛筆アイコン（✏️）をクリックして、新しいショートカットを入力します。"
+    "message": "**Translate It** を見つけて、必要なショートカットを設定します。"
   },
   "translation_activation_section_title": {
     "message": "翻訳の有効化方法"

--- a/src/app/main/options.js
+++ b/src/app/main/options.js
@@ -67,28 +67,22 @@ async function initializeApp() {
     await setI18nLocale(userLocale);
     logger.debug('� vue-i18n plugin locale set:', userLocale)
 
-    // Check for tab query parameter for Firefox shortcuts navigation and hash URLs
+    // Check for Help navigation query and hash URLs
     let initialRoute = '/languages'; // Default to languages tab
-    let shouldNavigateToHelp = false;
 
     try {
-      // First check query parameters (for Firefox shortcuts)
+      // First check query parameters
       const urlParams = new URLSearchParams(window.location.search);
       const tabParam = urlParams.get('tab');
 
-      if (tabParam === 'shortcuts') {
-        // For Firefox shortcuts navigation, redirect to help tab
+      if (tabParam === 'help') {
+        // Redirect Help query navigation to the Help tab
         initialRoute = '/help';
-        shouldNavigateToHelp = true;
-        logger.debug('Detected tab=shortcuts parameter, redirecting to help tab for Firefox');
-      } else if (tabParam === 'help') {
-        // For Firefox help navigation, redirect to help tab
-        initialRoute = '/help';
-        logger.debug('Detected tab=help parameter, redirecting to help tab for Firefox');
+        logger.debug('Detected tab=help parameter, redirecting to help tab');
       } else {
         // If no query parameter, check hash URL
         const hash = window.location.hash.replace('#', '').replace('/', '');
-        if (hash === 'help' || hash === 'shortcuts') {
+        if (hash === 'help') {
           initialRoute = '/help';
           logger.debug(`Detected hash #${hash}, redirecting to help tab`);
         } else if (hash && hash !== '') {
@@ -141,33 +135,6 @@ async function initializeApp() {
       ]
     })
     logger.debug('� Router created successfully')
-
-    // Handle Firefox shortcuts navigation after router is ready
-    router.isReady().then(() => {
-      if (shouldNavigateToHelp) {
-        logger.debug('� Navigating to help tab for Firefox shortcuts');
-        // Use replace to avoid adding to history
-        router.replace('/help');
-
-        // Additional fallback: manually set hash after a delay
-        setTimeout(() => {
-          if (window.location.hash !== '#/help') {
-            logger.debug('� Setting hash manually as fallback');
-            window.location.hash = '#/help';
-          }
-        }, 100);
-      }
-    }).catch(error => {
-      logger.error('Router ready failed:', error);
-
-      // Fallback navigation if router fails
-      if (shouldNavigateToHelp) {
-        logger.debug('� Using fallback navigation to help tab');
-        setTimeout(() => {
-          window.location.hash = '#/help';
-        }, 500);
-      }
-    });
 
     // Create Vue app
     logger.debug('� Creating Vue app...')

--- a/src/apps/options/tabs/HelpTab.vue
+++ b/src/apps/options/tabs/HelpTab.vue
@@ -85,20 +85,13 @@ const toggleAccordion = (section) => {
 }
 
 const shortcutHelpContent = computed(() => {
-  const content = `${t('help_shortcut_content_p1') || 'To use this extension, you have several options:'}
+  const content = `${t('help_shortcut_content_p1') || 'To customize keyboard shortcuts:'}
 
-1. ${t('help_shortcut_content_li1') || 'Select text on any webpage and press **Ctrl+/** (**Cmd+/** on Mac) to translate it instantly.'}
-2. ${t('help_shortcut_content_li2') || 'Right-click on selected text and choose **"Translate Selected Text"** from the context menu.'}
-3. ${t('help_shortcut_content_li3') || 'Click on the extension icon in the toolbar to open the translation popup.'}
-4. ${t('help_shortcut_content_li4') || 'Use the side panel for continuous translation work (**Chrome only**).'}
-
----
-
-${t('help_shortcut_content_p2') || 'To customize keyboard shortcuts in Chrome:'}
-
-1. ${t('help_shortcut_content_chrome_li1') || 'Go to **chrome://extensions/**'}
-2. ${t('help_shortcut_content_chrome_li2') || 'Click on the menu **(☰)** in the top-left corner'}
-3. ${t('help_shortcut_content_chrome_li3') || 'Select **"Keyboard shortcuts"** and customize as needed'}`
+1. ${t('help_shortcut_content_li1') || 'Right-click the **Translate It** icon in the browser toolbar.'}
+2. ${t('help_shortcut_content_li2') || 'Open **Settings**.'}
+3. ${t('help_shortcut_content_li3') || 'Select **Manage Shortcuts**.'}
+4. ${t('help_shortcut_content_li4') || "Your browser's shortcut settings page will open."}
+5. ${t('help_shortcut_content_p2') || 'Find **Translate It** and configure the shortcuts you want.'}`
 
   try {
     const markdownElement = SimpleMarkdown.render(content)
@@ -157,31 +150,6 @@ watch([sanitizedShortcutHelp, sanitizedApiKeysHelp], () => {
 // Process links when component mounts and when accordions are clicked
 onMounted(() => {
   setTimeout(addTargetBlankToLinks, 200)
-
-  // Check if user came from shortcuts menu and auto-open shortcuts section
-  try {
-    const urlParams = new URLSearchParams(window.location.search);
-    const tabParam = urlParams.get('tab');
-
-    if (tabParam === 'shortcuts') {
-      logger.debug('Auto-opening shortcuts accordion for Firefox user');
-      // Auto-open the shortcuts section
-      openAccordion.value = 'shortcut';
-
-      // Scroll to shortcuts section after a brief delay
-      setTimeout(() => {
-        const shortcutsElement = document.querySelector('.accordion-item');
-        if (shortcutsElement) {
-          shortcutsElement.scrollIntoView({ behavior: 'smooth', block: 'start' });
-        }
-      }, 300);
-    } else if (tabParam === 'help') {
-      logger.debug('Firefox user accessing help tab via context menu');
-      // No auto-open needed for general help access, just log the navigation
-    }
-  } catch (e) {
-    logger.debug('Failed to check URL parameters for auto-opening accordion:', e);
-  }
 
   // Also process when accordion is clicked
   document.addEventListener('click', (e) => {

--- a/src/components/feature/ConfigureShortcutButton.test.js
+++ b/src/components/feature/ConfigureShortcutButton.test.js
@@ -1,0 +1,107 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+
+const mocks = vi.hoisted(() => ({
+  browserAPI: { value: null },
+  logger: {
+    debug: vi.fn(),
+    error: vi.fn()
+  }
+}))
+
+vi.mock('@/composables/core/useBrowserAPI.js', () => ({
+  useBrowserAPI: () => ({ api: mocks.browserAPI })
+}))
+
+vi.mock('@/composables/shared/useUnifiedI18n.js', () => ({
+  useUnifiedI18n: () => ({ t: (key) => key })
+}))
+
+vi.mock('@/shared/logging/logger.js', () => ({
+  getScopedLogger: () => mocks.logger
+}))
+
+import ConfigureShortcutButton from './ConfigureShortcutButton.vue'
+
+const createBrowserApi = (browserName = 'Chrome') => ({
+  commands: {
+    getAll: vi.fn().mockResolvedValue([]),
+    openShortcutSettings: vi.fn().mockResolvedValue(undefined)
+  },
+  runtime: {
+    getBrowserInfo: vi.fn().mockResolvedValue({ name: browserName }),
+    getURL: vi.fn((path) => path)
+  },
+  tabs: {
+    create: vi.fn().mockResolvedValue(undefined)
+  }
+})
+
+describe('ConfigureShortcutButton', () => {
+  let wrapper
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.browserAPI.value = createBrowserApi()
+  })
+
+  afterEach(() => {
+    wrapper?.unmount()
+    wrapper = undefined
+  })
+
+  const mountButton = () => {
+    wrapper = mount(ConfigureShortcutButton, {
+      props: { commandName: 'SELECT-ELEMENT-COMMAND' },
+      global: {
+        stubs: {
+          BaseButton: {
+            props: ['disabled'],
+            emits: ['click'],
+            template: '<button :disabled="disabled" @click="$emit(\'click\')"><slot /></button>'
+          }
+        }
+      }
+    })
+    return wrapper
+  }
+
+  it('opens native Firefox shortcut settings', async () => {
+    const browserApi = createBrowserApi('Firefox')
+    mocks.browserAPI.value = browserApi
+
+    await mountButton().find('button').trigger('click')
+
+    expect(browserApi.commands.openShortcutSettings).toHaveBeenCalledOnce()
+    expect(browserApi.tabs.create).not.toHaveBeenCalled()
+    expect(browserApi.runtime.getURL).not.toHaveBeenCalled()
+  })
+
+  it('opens Chrome shortcut settings URL outside Firefox', async () => {
+    const browserApi = createBrowserApi('Chrome')
+    mocks.browserAPI.value = browserApi
+
+    await mountButton().find('button').trigger('click')
+
+    expect(browserApi.tabs.create).toHaveBeenCalledWith({
+      url: 'chrome://extensions/shortcuts'
+    })
+    expect(browserApi.commands.openShortcutSettings).not.toHaveBeenCalled()
+  })
+
+  it('logs Firefox shortcut API failures without opening a legacy options URL', async () => {
+    const browserApi = createBrowserApi('Firefox')
+    const error = new Error('shortcut settings unavailable')
+    browserApi.commands.openShortcutSettings.mockRejectedValue(error)
+    mocks.browserAPI.value = browserApi
+
+    await mountButton().find('button').trigger('click')
+
+    expect(mocks.logger.error).toHaveBeenCalledWith(
+      'Failed to open shortcuts page:',
+      error
+    )
+    expect(browserApi.tabs.create).not.toHaveBeenCalled()
+    expect(browserApi.runtime.getURL).not.toHaveBeenCalled()
+  })
+})

--- a/src/components/feature/ConfigureShortcutButton.vue
+++ b/src/components/feature/ConfigureShortcutButton.vue
@@ -84,20 +84,26 @@ const fetchShortcuts = async () => {
 
 const openShortcutSettings = async () => {
   try {
-    let url = "chrome://extensions/shortcuts";
-    
-    // Check if we are on Firefox
-    if (browserAPI.value && typeof browserAPI.value.runtime?.getBrowserInfo === 'function') {
+    let browserName = null;
+    if (typeof browserAPI.value?.runtime?.getBrowserInfo === 'function') {
       try {
-        const browserInfo = await browserAPI.value.runtime.getBrowserInfo();
-        if (browserInfo.name === "Firefox") {
-          url = browserAPI.value.runtime.getURL("src/html/options.html?tab=shortcuts");
-        }
+        browserName = (await browserAPI.value.runtime.getBrowserInfo())?.name;
       } catch (e) {
         logger.debug("Failed to get browser info, using default shortcuts URL", e);
       }
     }
-    
+
+    if (browserName === 'Firefox') {
+      if (typeof browserAPI.value?.commands?.openShortcutSettings !== 'function') {
+        logger.error("Firefox shortcut settings API unavailable");
+        return;
+      }
+
+      await browserAPI.value.commands.openShortcutSettings();
+      return;
+    }
+
+    const url = "chrome://extensions/shortcuts";
     if (browserAPI.value?.tabs) {
       await browserAPI.value.tabs.create({ url });
     } else {
@@ -105,10 +111,6 @@ const openShortcutSettings = async () => {
     }
   } catch (err) {
     logger.error("Failed to open shortcuts page:", err);
-    const fallbackUrl = browserAPI.value?.runtime?.getURL 
-      ? browserAPI.value.runtime.getURL("src/html/options.html?tab=shortcuts") 
-      : "src/html/options.html?tab=shortcuts";
-    window.open(fallbackUrl, '_blank');
   }
 }
 

--- a/src/core/managers/context-menu.js
+++ b/src/core/managers/context-menu.js
@@ -922,81 +922,54 @@ export class ContextMenuManager extends ResourceTracker {
 
         case ACTION_CONTEXT_MENU_SHORTCUTS_ID:
           try {
-            let url;
-
-            // Check if current tab is accessible and determine appropriate shortcuts URL
-            const [activeTab] = await browser.tabs.query({ active: true, currentWindow: true });
-
-            if (activeTab) {
-              // Check if current tab is accessible before determining shortcuts URL
-              const tabAccess = await tabPermissionChecker.checkTabAccess(activeTab.id);
-
-              if (!tabAccess.isAccessible) {
-                logger.debug(`Current tab is restricted (${tabAccess.errorMessage}), using fallback shortcuts URL`);
+            let browserName = null;
+            if (typeof browser.runtime?.getBrowserInfo === 'function') {
+              try {
+                browserName = (await browser.runtime.getBrowserInfo())?.name;
+              } catch (browserInfoError) {
+                logger.debug("Browser info not available, using default Chrome shortcuts URL", browserInfoError);
               }
-
-              if (browser.runtime && typeof browser.runtime.getBrowserInfo === 'function') {
-                try {
-                  const browserInfo = await browser.runtime.getBrowserInfo();
-                  if (browserInfo.name === "Firefox") {
-                    // Use extension's options page for Firefox with query param
-                    url = browser.runtime.getURL("src/html/options.html?tab=shortcuts");
-                  } else {
-                    // Use Chrome shortcuts page
-                    url = "chrome://extensions/shortcuts";
-                  }
-                } catch (browserInfoError) {
-                  logger.debug("Browser info not available, using default Chrome shortcuts URL", browserInfoError);
-                  url = "chrome://extensions/shortcuts";
-                }
-              } else {
-                // Fallback to Chrome shortcuts
-                url = "chrome://extensions/shortcuts";
-              }
-            } else {
-              // No active tab, use default behavior
-              url = "chrome://extensions/shortcuts";
             }
 
-            await browser.tabs.create({ url });
+            if (browserName === "Firefox") {
+              if (typeof browser.commands?.openShortcutSettings === 'function') {
+                try {
+                  await browser.commands.openShortcutSettings();
+                } catch (error) {
+                  logger.error("Could not open Firefox shortcut settings:", error);
+                }
+              } else {
+                logger.error("Firefox shortcut settings API unavailable");
+              }
+            } else {
+              await browser.tabs.create({ url: "chrome://extensions/shortcuts" });
+            }
           } catch (e) {
             if (ExtensionContextManager.isContextError(e)) {
               ExtensionContextManager.handleContextError(e, 'context-menu:open-shortcuts');
             } else {
               logger.error("Could not open shortcuts page:", e);
             }
-            // Final fallback - try to open options page instead
-            try {
-              await browser.tabs.create({ url: browser.runtime.getURL("src/html/options.html?tab=shortcuts") });
-            } catch (fallbackError) {
-              if (!ExtensionContextManager.isContextError(fallbackError)) {
-                logger.error("Failed to open fallback shortcuts page:", fallbackError);
-              }
-            }
           }
           break;
 
-        case HELP_MENU_ID:
-          // Check browser type for proper help navigation
-          if (browser.runtime && typeof browser.runtime.getBrowserInfo === 'function') {
-            try {
-              const browserInfo = await browser.runtime.getBrowserInfo();
-              if (browserInfo.name === "Firefox") {
-                // Use query parameter for Firefox to ensure proper tab selection
-                await focusOrCreateTab(browser.runtime.getURL("src/html/options.html?tab=help"));
-              } else {
-                // Use hash for Chrome and other browsers
-                await focusOrCreateTab(browser.runtime.getURL("src/html/options.html#help"));
-              }
-            } catch (browserInfoError) {
-              logger.debug("Browser info not available, using default hash URL", browserInfoError);
-              await focusOrCreateTab(browser.runtime.getURL("src/html/options.html#help"));
-            }
+        case HELP_MENU_ID: {
+          const message = {
+            action: MessageActions.OPEN_OPTIONS_PAGE,
+            data: { anchor: 'help' }
+          };
+          const backgroundService = globalThis.backgroundService;
+          const handler = backgroundService?.messageHandler?.getHandlerForMessage?.(
+            MessageActions.OPEN_OPTIONS_PAGE
+          );
+
+          if (handler) {
+            await handler(message, { tab: null }, () => {});
           } else {
-            // Fallback to hash URL
-            await focusOrCreateTab(browser.runtime.getURL("src/html/options.html#help"));
+            await browser.runtime.sendMessage(message);
           }
           break;
+        }
 
 
         default:

--- a/src/core/managers/context-menu.js
+++ b/src/core/managers/context-menu.js
@@ -38,6 +38,8 @@ const ACTION_CONTEXT_MENU_SUBTITLE_ID = "open-subtitle-page";
 const ACTION_CONTEXT_MENU_SHORTCUTS_ID = "open-shortcuts-page";
 const HELP_MENU_ID = "open-help-page";
 const API_PROVIDER_PARENT_ID = "api-provider-parent";
+const TRANSLATORS_PARENT_ID = "translators-parent";
+const SETTINGS_PARENT_ID = "settings-parent";
 const API_PROVIDER_ITEM_ID_PREFIX = "api-provider-";
 
 // Settings required to build context menus and filter available providers.
@@ -567,60 +569,83 @@ export class ContextMenuManager extends ResourceTracker {
           }
         }
 
-        // --- 2.3.4 PDF Menu (Before Subtitle) ---
-        if (visibility.ACTION_CONTEXT_PDF_TRANSLATOR !== false) {
-          await this.createMenu({
-            id: ACTION_CONTEXT_MENU_PDF_ID,
-            title: (await getTranslationString("pdf_app_title", locale)) || "PDF Translator",
-            contexts: ["action"],
-          });
-        }
+        // --- 2.4. Translators Menu ---
+        const isTranslatorsMenuVisible =
+          visibility.ACTION_CONTEXT_PDF_TRANSLATOR !== false ||
+          visibility.ACTION_CONTEXT_SUBTITLE_TRANSLATOR !== false;
 
-        // --- 2.3.5 Subtitle Menu (Before Options) ---
-        if (visibility.ACTION_CONTEXT_SUBTITLE_TRANSLATOR !== false) {
+        if (isTranslatorsMenuVisible) {
           await this.createMenu({
-            id: ACTION_CONTEXT_MENU_SUBTITLE_ID,
-            title: (await getTranslationString("subtitle_app_title", locale)) || "Subtitle Translator",
-            contexts: ["action"],
-          });
-        }
-
-        // --- 2.4. Options Menu (Fourth option in Action menu) ---
-        if (visibility.ACTION_CONTEXT_OPTIONS) {
-          await this.createMenu({
-            id: ACTION_CONTEXT_MENU_OPTIONS_ID,
-            title: (await getTranslationString("context_menu_options", locale)) || "Options",
-            contexts: ["action"],
-          });
-        }
-
-        // --- Separator ---
-        if (visibility.ACTION_CONTEXT_SHORTCUTS || visibility.ACTION_CONTEXT_HELP) {
-          await this.createMenu({
-            id: "action-separator-1",
-            type: "separator",
-            contexts: ["action"],
-          });
-        }
-
-        // --- Other Action Menus ---
-        if (visibility.ACTION_CONTEXT_SHORTCUTS) {
-          await this.createMenu({
-            id: ACTION_CONTEXT_MENU_SHORTCUTS_ID,
+            id: TRANSLATORS_PARENT_ID,
             title:
-              (await getTranslationString("context_menu_shortcuts", locale)) ||
-              "Manage Shortcuts",
+              (await getTranslationString("context_menu_translators", locale)) ||
+              "Translators",
             contexts: ["action"],
           });
+
+          if (visibility.ACTION_CONTEXT_PDF_TRANSLATOR !== false) {
+            await this.createMenu({
+              id: ACTION_CONTEXT_MENU_PDF_ID,
+              parentId: TRANSLATORS_PARENT_ID,
+              title: (await getTranslationString("pdf_app_title", locale)) || "PDF Translator",
+              contexts: ["action"],
+            });
+          }
+
+          if (visibility.ACTION_CONTEXT_SUBTITLE_TRANSLATOR !== false) {
+            await this.createMenu({
+              id: ACTION_CONTEXT_MENU_SUBTITLE_ID,
+              parentId: TRANSLATORS_PARENT_ID,
+              title: (await getTranslationString("subtitle_app_title", locale)) || "Subtitle Translator",
+              contexts: ["action"],
+            });
+          }
         }
 
-        if (visibility.ACTION_CONTEXT_HELP) {
+        // --- 2.5. Settings Menu ---
+        const isSettingsMenuVisible =
+          visibility.ACTION_CONTEXT_OPTIONS ||
+          visibility.ACTION_CONTEXT_SHORTCUTS ||
+          visibility.ACTION_CONTEXT_HELP;
+
+        if (isSettingsMenuVisible) {
           await this.createMenu({
-            id: HELP_MENU_ID,
+            id: SETTINGS_PARENT_ID,
             title:
-              (await getTranslationString("context_menu_help", locale)) || "Help & Support",
+              (await getTranslationString("context_menu_settings", locale)) ||
+              "Settings",
             contexts: ["action"],
           });
+
+          if (visibility.ACTION_CONTEXT_OPTIONS) {
+            await this.createMenu({
+              id: ACTION_CONTEXT_MENU_OPTIONS_ID,
+              parentId: SETTINGS_PARENT_ID,
+              title: (await getTranslationString("context_menu_options", locale)) || "Options",
+              contexts: ["action"],
+            });
+          }
+
+          if (visibility.ACTION_CONTEXT_SHORTCUTS) {
+            await this.createMenu({
+              id: ACTION_CONTEXT_MENU_SHORTCUTS_ID,
+              parentId: SETTINGS_PARENT_ID,
+              title:
+                (await getTranslationString("context_menu_shortcuts", locale)) ||
+                "Manage Shortcuts",
+              contexts: ["action"],
+            });
+          }
+
+          if (visibility.ACTION_CONTEXT_HELP) {
+            await this.createMenu({
+              id: HELP_MENU_ID,
+              parentId: SETTINGS_PARENT_ID,
+              title:
+                (await getTranslationString("context_menu_help", locale)) || "Help & Support",
+              contexts: ["action"],
+            });
+          }
         }
         logger.debug("Action context menus created successfully.");
       } catch (e) {

--- a/src/core/managers/context-menu.test.js
+++ b/src/core/managers/context-menu.test.js
@@ -158,6 +158,10 @@ const CONTEXT_MENU_VISIBILITY = {
   ACTION_CONTEXT_HELP: true
 };
 
+const API_PROVIDER_PARENT_ID = 'api-provider-parent';
+const TRANSLATORS_PARENT_ID = 'translators-parent';
+const SETTINGS_PARENT_ID = 'settings-parent';
+
 const createSettings = (overrides = {}) => ({
   EXTENSION_ENABLED: true,
   TRANSLATE_WITH_SELECT_ELEMENT: true,
@@ -172,6 +176,14 @@ const createSettings = (overrides = {}) => ({
 
 const getCreatedMenuIds = () => mocks.browser.contextMenus.create.mock.calls
   .map(([menu]) => menu.id);
+
+const getCreatedMenus = () => mocks.browser.contextMenus.create.mock.calls
+  .map(([menu]) => menu);
+
+const getCreatedMenu = (id) => getCreatedMenus().find(menu => menu.id === id);
+
+const getActionMenus = () => getCreatedMenus()
+  .filter(menu => menu.contexts?.includes('action'));
 
 describe('ContextMenuManager keyed storage reads', () => {
   let manager;
@@ -247,6 +259,119 @@ describe('ContextMenuManager keyed storage reads', () => {
     expect(menuIds).not.toContain('action-translate-element');
     expect(menuIds).not.toContain('screen-capture-page');
     expect(menuIds).not.toContain('screen-capture-action');
+  });
+
+  it('creates the expected Action menu structure with nested children', async () => {
+    await manager._setupMenusInternal();
+
+    const topLevelActionIds = getActionMenus()
+      .filter(menu => !menu.parentId)
+      .map(menu => menu.id);
+
+    expect(topLevelActionIds).toEqual([
+      API_PROVIDER_PARENT_ID,
+      'action-translate-element',
+      'screen-capture-action',
+      TRANSLATORS_PARENT_ID,
+      SETTINGS_PARENT_ID
+    ]);
+    expect(getCreatedMenu('open-pdf-page').parentId).toBe(TRANSLATORS_PARENT_ID);
+    expect(getCreatedMenu('open-subtitle-page').parentId).toBe(TRANSLATORS_PARENT_ID);
+    expect(getCreatedMenu('open-options-page').parentId).toBe(SETTINGS_PARENT_ID);
+    expect(getCreatedMenu('open-shortcuts-page').parentId).toBe(SETTINGS_PARENT_ID);
+    expect(getCreatedMenu('open-help-page').parentId).toBe(SETTINGS_PARENT_ID);
+    expect(getActionMenus().some(menu => menu.type === 'separator' && !menu.parentId)).toBe(false);
+  });
+
+  it('preserves provider submenu creation and selected provider state', async () => {
+    await manager._setupMenusInternal();
+
+    expect(getCreatedMenu('api-provider-googlev2')).toMatchObject({
+      parentId: API_PROVIDER_PARENT_ID,
+      type: 'checkbox',
+      checked: true
+    });
+    expect(getCreatedMenu('api-provider-openai')).toMatchObject({
+      parentId: API_PROVIDER_PARENT_ID,
+      type: 'checkbox',
+      checked: false
+    });
+    expect(getCreatedMenus()).toContainEqual(expect.objectContaining({
+      parentId: API_PROVIDER_PARENT_ID,
+      type: 'separator'
+    }));
+  });
+
+  it.each([
+    ['both children enabled', { ACTION_CONTEXT_PDF_TRANSLATOR: true, ACTION_CONTEXT_SUBTITLE_TRANSLATOR: true }, ['open-pdf-page', 'open-subtitle-page']],
+    ['only PDF enabled', { ACTION_CONTEXT_PDF_TRANSLATOR: true, ACTION_CONTEXT_SUBTITLE_TRANSLATOR: false }, ['open-pdf-page']],
+    ['only Subtitle enabled', { ACTION_CONTEXT_PDF_TRANSLATOR: false, ACTION_CONTEXT_SUBTITLE_TRANSLATOR: true }, ['open-subtitle-page']]
+  ])('creates Translators parent for %s', async (_name, translatorVisibility, childIds) => {
+    mocks.storageManager.get.mockResolvedValue(createSettings({
+      CONTEXT_MENU_VISIBILITY: {
+        ...CONTEXT_MENU_VISIBILITY,
+        ...translatorVisibility
+      }
+    }));
+
+    await manager._setupMenusInternal();
+
+    expect(getCreatedMenu(TRANSLATORS_PARENT_ID)).toBeDefined();
+    expect(getCreatedMenus()
+      .filter(menu => menu.parentId === TRANSLATORS_PARENT_ID)
+      .map(menu => menu.id)).toEqual(childIds);
+  });
+
+  it('does not create Translators when both children are disabled', async () => {
+    mocks.storageManager.get.mockResolvedValue(createSettings({
+      CONTEXT_MENU_VISIBILITY: {
+        ...CONTEXT_MENU_VISIBILITY,
+        ACTION_CONTEXT_PDF_TRANSLATOR: false,
+        ACTION_CONTEXT_SUBTITLE_TRANSLATOR: false
+      }
+    }));
+
+    await manager._setupMenusInternal();
+
+    expect(getCreatedMenu(TRANSLATORS_PARENT_ID)).toBeUndefined();
+    expect(getCreatedMenu('open-pdf-page')).toBeUndefined();
+    expect(getCreatedMenu('open-subtitle-page')).toBeUndefined();
+  });
+
+  it('creates Settings parent with only enabled children', async () => {
+    mocks.storageManager.get.mockResolvedValue(createSettings({
+      CONTEXT_MENU_VISIBILITY: {
+        ...CONTEXT_MENU_VISIBILITY,
+        ACTION_CONTEXT_OPTIONS: false,
+        ACTION_CONTEXT_SHORTCUTS: true,
+        ACTION_CONTEXT_HELP: false
+      }
+    }));
+
+    await manager._setupMenusInternal();
+
+    expect(getCreatedMenu(SETTINGS_PARENT_ID)).toBeDefined();
+    expect(getCreatedMenus()
+      .filter(menu => menu.parentId === SETTINGS_PARENT_ID)
+      .map(menu => menu.id)).toEqual(['open-shortcuts-page']);
+  });
+
+  it('does not create Settings when all children are disabled', async () => {
+    mocks.storageManager.get.mockResolvedValue(createSettings({
+      CONTEXT_MENU_VISIBILITY: {
+        ...CONTEXT_MENU_VISIBILITY,
+        ACTION_CONTEXT_OPTIONS: false,
+        ACTION_CONTEXT_SHORTCUTS: false,
+        ACTION_CONTEXT_HELP: false
+      }
+    }));
+
+    await manager._setupMenusInternal();
+
+    expect(getCreatedMenu(SETTINGS_PARENT_ID)).toBeUndefined();
+    expect(getCreatedMenu('open-options-page')).toBeUndefined();
+    expect(getCreatedMenu('open-shortcuts-page')).toBeUndefined();
+    expect(getCreatedMenu('open-help-page')).toBeUndefined();
   });
 
   it('preserves defaults when requested settings are absent', async () => {

--- a/src/core/managers/context-menu.test.js
+++ b/src/core/managers/context-menu.test.js
@@ -11,11 +11,13 @@ const mocks = vi.hoisted(() => {
       })
     },
     commands: {
-      getAll: vi.fn().mockResolvedValue([])
+      getAll: vi.fn().mockResolvedValue([]),
+      openShortcutSettings: vi.fn().mockResolvedValue(undefined)
     },
     runtime: {
       sendMessage: vi.fn(),
-      getURL: vi.fn((path) => path)
+      getURL: vi.fn((path) => path),
+      getBrowserInfo: vi.fn().mockResolvedValue({ name: 'Chrome' })
     },
     storage: {
       onChanged: {
@@ -48,6 +50,9 @@ const mocks = vi.hoisted(() => {
     getEffectiveProviderAsync: vi.fn().mockResolvedValue('googlev2'),
     getDebugModeAsync: vi.fn().mockResolvedValue(false),
     getTranslationString: vi.fn((key) => key),
+    tabPermissionChecker: {
+      checkTabAccess: vi.fn().mockResolvedValue({ isAccessible: true })
+    },
     utilsFactory: {
       getI18nUtils: vi.fn()
     }
@@ -110,9 +115,7 @@ vi.mock('@/core/extensionContext.js', () => ({
 }));
 
 vi.mock('@/core/tabPermissions.js', () => ({
-  tabPermissionChecker: {
-    checkTabAccess: vi.fn().mockResolvedValue({ isAccessible: true })
-  }
+  tabPermissionChecker: mocks.tabPermissionChecker
 }));
 
 vi.mock('@/core/ExtensionAppLauncher.js', () => ({
@@ -124,6 +127,7 @@ vi.mock('@/core/background/handlers/lazy/handleElementSelectionLazy.js', () => (
 }));
 
 import { ContextMenuManager } from './context-menu.js';
+import { MessageActions } from '@/shared/messaging/core/MessageActions.js';
 
 const CONTEXT_MENU_SETTING_KEYS = [
   'EXTENSION_ENABLED',
@@ -190,6 +194,9 @@ describe('ContextMenuManager keyed storage reads', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    delete globalThis.backgroundService;
+    mocks.browser.commands.openShortcutSettings.mockResolvedValue(undefined);
+    mocks.browser.runtime.getBrowserInfo.mockResolvedValue({ name: 'Chrome' });
     mocks.getTranslationString.mockImplementation((key) => key);
     mocks.utilsFactory.getI18nUtils.mockResolvedValue({
       getTranslationString: mocks.getTranslationString
@@ -547,6 +554,72 @@ describe('ContextMenuManager keyed storage reads', () => {
       'Error setting new API provider:',
       error
     );
+  });
+
+  it('routes Help through the canonical Options handler', async () => {
+    const openOptionsHandler = vi.fn().mockResolvedValue({ success: true });
+    const getHandlerForMessage = vi.fn().mockReturnValue(openOptionsHandler);
+    globalThis.backgroundService = {
+      messageHandler: { getHandlerForMessage }
+    };
+
+    await manager.handleMenuClick({ menuItemId: 'open-help-page' });
+
+    expect(getHandlerForMessage).toHaveBeenCalledWith(MessageActions.OPEN_OPTIONS_PAGE);
+    expect(openOptionsHandler).toHaveBeenCalledWith(
+      {
+        action: MessageActions.OPEN_OPTIONS_PAGE,
+        data: { anchor: 'help' }
+      },
+      { tab: null },
+      expect.any(Function)
+    );
+    expect(mocks.browser.runtime.sendMessage).not.toHaveBeenCalled();
+    expect(mocks.browser.runtime.getURL).not.toHaveBeenCalled();
+  });
+
+  it('falls back to messaging for canonical Help navigation', async () => {
+    await manager.handleMenuClick({ menuItemId: 'open-help-page' });
+
+    expect(mocks.browser.runtime.sendMessage).toHaveBeenCalledWith({
+      action: MessageActions.OPEN_OPTIONS_PAGE,
+      data: { anchor: 'help' }
+    });
+    expect(mocks.browser.runtime.getURL).not.toHaveBeenCalled();
+  });
+
+  it('opens native Firefox shortcut settings without checking the active tab', async () => {
+    mocks.browser.runtime.getBrowserInfo.mockResolvedValue({ name: 'Firefox' });
+
+    await manager.handleMenuClick({ menuItemId: 'open-shortcuts-page' });
+
+    expect(mocks.browser.commands.openShortcutSettings).toHaveBeenCalledOnce();
+    expect(mocks.browser.tabs.create).not.toHaveBeenCalled();
+    expect(mocks.tabPermissionChecker.checkTabAccess).not.toHaveBeenCalled();
+  });
+
+  it('opens Chrome shortcut settings URL outside Firefox', async () => {
+    await manager.handleMenuClick({ menuItemId: 'open-shortcuts-page' });
+
+    expect(mocks.browser.tabs.create).toHaveBeenCalledWith({
+      url: 'chrome://extensions/shortcuts'
+    });
+    expect(mocks.browser.commands.openShortcutSettings).not.toHaveBeenCalled();
+  });
+
+  it('logs Firefox shortcut API failures without opening the Help page', async () => {
+    const error = new Error('shortcut settings unavailable');
+    mocks.browser.runtime.getBrowserInfo.mockResolvedValue({ name: 'Firefox' });
+    mocks.browser.commands.openShortcutSettings.mockRejectedValue(error);
+
+    await manager.handleMenuClick({ menuItemId: 'open-shortcuts-page' });
+
+    expect(mocks.logger.error).toHaveBeenCalledWith(
+      'Could not open Firefox shortcut settings:',
+      error
+    );
+    expect(mocks.browser.tabs.create).not.toHaveBeenCalled();
+    expect(mocks.browser.runtime.sendMessage).not.toHaveBeenCalled();
   });
 
   it('keeps Select Element title failure local to its menu paths', async () => {

--- a/src/features/element-selection/SelectElementNotificationManager.js
+++ b/src/features/element-selection/SelectElementNotificationManager.js
@@ -15,7 +15,9 @@ class SelectElementNotificationManager extends ResourceTracker {
     
     this.notificationManager = notificationManager;
     this.toastId = null;
-    this.showPending = false;
+    this.toastGeneration = null;
+    this.notificationGeneration = 0;
+    this.isStatusToast = false;
     this.isInitialized = false;
     
     this.logger = getScopedLogger(LOG_COMPONENTS.ELEMENT_SELECTION, 'SelectElementNotificationManager');
@@ -49,6 +51,34 @@ class SelectElementNotificationManager extends ResourceTracker {
     this.addEventListener(pageEventBus, 'cancel-select-element-mode', () => this.dismissNotification());
     this.addEventListener(pageEventBus, 'show-select-element-info', (data) => this.showInfoNotification(data));
   }
+
+  _startNotificationLifecycle() {
+    this.notificationGeneration += 1;
+
+    if (this.toastId) {
+      this.notificationManager.dismiss(this.toastId);
+    }
+
+    this.toastId = null;
+    this.toastGeneration = null;
+    this.isStatusToast = false;
+
+    return {
+      generation: this.notificationGeneration,
+      toastId: `select-element-toast-${this.notificationGeneration}`
+    };
+  }
+
+  _isCurrentGeneration(generation) {
+    return generation === this.notificationGeneration;
+  }
+
+  _ownsStatusToast(generation, toastId) {
+    return this.isStatusToast
+      && this.toastGeneration === generation
+      && this.toastId === toastId
+      && this._isCurrentGeneration(generation);
+  }
   
   async showNotification(data = {}) {
     // Safety check for null data from events
@@ -58,20 +88,18 @@ class SelectElementNotificationManager extends ResourceTracker {
     const isTopFrame = window === window.top;
     if (!isTopFrame) return;
 
-    this.showPending = true;
+    const { generation, toastId } = this._startNotificationLifecycle();
     try {
       const { getTranslationString } = await utilsFactory.getI18nUtils();
-      
-      // Check if we should still show this after async call
-      if (!this.showPending) return;
+      if (!this._isCurrentGeneration(generation)) return;
 
       const cancelLabel = await getTranslationString('SELECT_ELEMENT_CANCEL') || 'Cancel';
+      if (!this._isCurrentGeneration(generation)) return;
+
       const isMobile = deviceDetector.isMobile();
       const messageKey = isMobile ? 'SELECT_ELEMENT_MODE_ACTIVATED_MOBILE' : 'SELECT_ELEMENT_MODE_ACTIVATED';
       const message = await getTranslationString(messageKey) || (isMobile ? 'Drag over text to translate.' : 'Click text to translate.');
-
-      // Final check before showing
-      if (!this.showPending) return;
+      if (!this._isCurrentGeneration(generation)) return;
 
       const actions = [
         {
@@ -80,16 +108,21 @@ class SelectElementNotificationManager extends ResourceTracker {
         }
       ];
 
-      // Use central showStatus for a consistent experience
-      this.toastId = this.notificationManager.showStatus(message, {
-        id: 'select-element-toast',
+      // Status IDs must remain feature-owned across rapid activation cycles.
+      this.notificationManager.show(message, 'status', 0, {
+        id: toastId,
+        persistent: true,
         actions
       });
+      if (!this._isCurrentGeneration(generation)) return;
 
+      this.toastId = toastId;
+      this.toastGeneration = generation;
+      this.isStatusToast = true;
     } catch (error) {
-      this.logger.error('Error showing Select Element notification:', error);
-    } finally {
-      this.showPending = false;
+      if (this._isCurrentGeneration(generation)) {
+        this.logger.error('Error showing Select Element notification:', error);
+      }
     }
   }
   
@@ -98,7 +131,9 @@ class SelectElementNotificationManager extends ResourceTracker {
     if (!data) data = {};
 
     const isTopFrame = window === window.top;
-    if (!this.toastId || !isTopFrame) {
+    const generation = this.notificationGeneration;
+    const toastId = this.toastId;
+    if (!this._ownsStatusToast(generation, toastId) || !isTopFrame) {
       this.logger.debug(`[SelectElementNotificationManager] Skip update - toastId: ${this.toastId}, isTopFrame: ${isTopFrame}`);
       return;
     }
@@ -106,7 +141,10 @@ class SelectElementNotificationManager extends ResourceTracker {
     try {
       if (data.status === TRANSLATION_STATUS.TRANSLATING) {
         const i18n = await utilsFactory.getI18nUtils();
+        if (!this._ownsStatusToast(generation, toastId)) return;
+
         let translatingMessage = await i18n.getTranslationString('SELECT_ELEMENT_TRANSLATING') || 'Translating...';
+        if (!this._ownsStatusToast(generation, toastId)) return;
 
         // Show progress based on API requests
         if (data.progress && data.progress.completed !== undefined && data.progress.total !== undefined) {
@@ -117,17 +155,11 @@ class SelectElementNotificationManager extends ResourceTracker {
           this.logger.debug(`[SelectElementNotificationManager] Updating toast with: ${translatingMessage}`);
         }
 
-        // CRITICAL: Re-check toastId after async await
-        if (!this.toastId) return;
-
         const cancelLabel = await i18n.getTranslationString('SELECT_ELEMENT_CANCEL') || 'Cancel';
+        if (!this._ownsStatusToast(generation, toastId)) return;
 
-        // Final safety check
-        if (!this.toastId) return;
-
-        // Update existing notification - ALWAYS use 'select-element-toast' as ID for safety
-        this.notificationManager.update(this.toastId, translatingMessage, {
-          id: 'select-element-toast',
+        this.notificationManager.update(toastId, translatingMessage, {
+          id: toastId,
           type: 'status',
           persistent: true,
           actions: [{
@@ -142,10 +174,15 @@ class SelectElementNotificationManager extends ResourceTracker {
   }
   
   dismissNotification() {
-    this.showPending = false;
-    if (this.toastId) {
-      this.notificationManager.dismiss(this.toastId);
-      this.toastId = null;
+    this.notificationGeneration += 1;
+    const toastId = this.toastId;
+
+    this.toastId = null;
+    this.toastGeneration = null;
+    this.isStatusToast = false;
+
+    if (toastId) {
+      this.notificationManager.dismiss(toastId);
     }
   }
 
@@ -162,10 +199,10 @@ class SelectElementNotificationManager extends ResourceTracker {
     const isTopFrame = window === window.top;
     if (!isTopFrame) return;
 
-    this.dismissNotification();
+    const { toastId } = this._startNotificationLifecycle();
 
     const message = data.message || 'No translatable text was found in this element.';
-    this.notificationManager.show(message, 'info', 4000, { id: 'select-element-toast' });
+    this.notificationManager.show(message, 'info', 4000, { id: toastId });
   }
   
   async cleanup() {

--- a/src/features/element-selection/SelectElementNotificationManager.test.js
+++ b/src/features/element-selection/SelectElementNotificationManager.test.js
@@ -69,7 +69,6 @@ describe('SelectElementNotificationManager', () => {
     });
 
     mockNotificationManager = {
-      showStatus: vi.fn(() => 'test-toast-id'),
       update: vi.fn(),
       dismiss: vi.fn(),
       show: vi.fn(() => 'info-toast-id')
@@ -102,7 +101,7 @@ describe('SelectElementNotificationManager', () => {
       global.window = { top: {} }; // window !== window.top
       
       await manager.showNotification();
-      expect(mockNotificationManager.showStatus).not.toHaveBeenCalled();
+      expect(mockNotificationManager.show).not.toHaveBeenCalled();
       
       global.window = originalWindow;
     });
@@ -112,9 +111,11 @@ describe('SelectElementNotificationManager', () => {
       
       await manager.showNotification();
       
-      expect(mockNotificationManager.showStatus).toHaveBeenCalledWith(
+      expect(mockNotificationManager.show).toHaveBeenCalledWith(
         'Mocked_SELECT_ELEMENT_MODE_ACTIVATED',
-        expect.objectContaining({ id: 'select-element-toast' })
+        'status',
+        0,
+        expect.objectContaining({ id: expect.stringMatching(/^select-element-toast-\d+$/) })
       );
     });
 
@@ -124,8 +125,10 @@ describe('SelectElementNotificationManager', () => {
       // Should not throw
       await manager.showNotification(null);
       
-      expect(mockNotificationManager.showStatus).toHaveBeenCalledWith(
+      expect(mockNotificationManager.show).toHaveBeenCalledWith(
         'Mocked_SELECT_ELEMENT_MODE_ACTIVATED',
+        'status',
+        0,
         expect.anything()
       );
     });
@@ -135,8 +138,10 @@ describe('SelectElementNotificationManager', () => {
       
       await manager.showNotification();
       
-      expect(mockNotificationManager.showStatus).toHaveBeenCalledWith(
+      expect(mockNotificationManager.show).toHaveBeenCalledWith(
         'Mocked_SELECT_ELEMENT_MODE_ACTIVATED_MOBILE',
+        'status',
+        0,
         expect.anything()
       );
     });
@@ -157,18 +162,59 @@ describe('SelectElementNotificationManager', () => {
       resolveI18n({ getTranslationString: vi.fn(() => Promise.resolve('msg')) });
       await showPromise;
 
-      expect(mockNotificationManager.showStatus).not.toHaveBeenCalled();
+      expect(mockNotificationManager.show).not.toHaveBeenCalled();
+    });
+
+    it('uses a new toast ID for each rapid activation and dismisses both', async () => {
+      await manager.showNotification();
+      const firstToastId = manager.toastId;
+      manager.dismissNotification();
+
+      await manager.showNotification();
+      const secondToastId = manager.toastId;
+      manager.dismissNotification();
+
+      expect(firstToastId).not.toBe(secondToastId);
+      expect(mockNotificationManager.dismiss).toHaveBeenNthCalledWith(1, firstToastId);
+      expect(mockNotificationManager.dismiss).toHaveBeenNthCalledWith(2, secondToastId);
+    });
+
+    it('does not publish a stale asynchronous show after a newer activation', async () => {
+      const { utilsFactory } = await import('@/utils/UtilsFactory.js');
+      let resolveFirstI18n;
+      let resolveSecondI18n;
+      const firstI18n = new Promise(resolve => { resolveFirstI18n = resolve; });
+      const secondI18n = new Promise(resolve => { resolveSecondI18n = resolve; });
+      const i18n = { getTranslationString: vi.fn(() => Promise.resolve('message')) };
+      utilsFactory.getI18nUtils
+        .mockImplementationOnce(() => firstI18n)
+        .mockImplementationOnce(() => secondI18n);
+
+      const firstShow = manager.showNotification();
+      manager.dismissNotification();
+      const secondShow = manager.showNotification();
+
+      resolveFirstI18n(i18n);
+      await firstShow;
+      expect(mockNotificationManager.show).not.toHaveBeenCalled();
+
+      resolveSecondI18n(i18n);
+      await secondShow;
+
+      expect(mockNotificationManager.show).toHaveBeenCalledTimes(1);
+      expect(manager.toastId).toBe(mockNotificationManager.show.mock.calls[0][3].id);
     });
   });
 
   describe('updateNotification', () => {
     it('should update notification when status is translating', async () => {
-      manager.toastId = 'existing-toast';
+      await manager.showNotification();
+      const toastId = manager.toastId;
 
       await manager.updateNotification({ status: 'translating' });
 
       expect(mockNotificationManager.update).toHaveBeenCalledWith(
-        'existing-toast',
+        toastId,
         'Mocked_SELECT_ELEMENT_TRANSLATING',
         {
           actions: [
@@ -177,7 +223,7 @@ describe('SelectElementNotificationManager', () => {
               onClick: expect.any(Function),
             },
           ],
-          id: 'select-element-toast',
+          id: toastId,
           persistent: true,
           type: 'status',
         }
@@ -185,7 +231,8 @@ describe('SelectElementNotificationManager', () => {
     });
 
     it('should update notification with progress when status is translating', async () => {
-      manager.toastId = 'existing-toast';
+      await manager.showNotification();
+      const toastId = manager.toastId;
 
       await manager.updateNotification({
         status: 'translating',
@@ -193,7 +240,7 @@ describe('SelectElementNotificationManager', () => {
       });
 
       expect(mockNotificationManager.update).toHaveBeenCalledWith(
-        'existing-toast',
+        toastId,
         'Mocked_SELECT_ELEMENT_TRANSLATING (2/5)...',
         {
           actions: [
@@ -202,7 +249,7 @@ describe('SelectElementNotificationManager', () => {
               onClick: expect.any(Function),
             },
           ],
-          id: 'select-element-toast',
+          id: toastId,
           persistent: true,
           type: 'status',
         }
@@ -210,16 +257,37 @@ describe('SelectElementNotificationManager', () => {
     });
 
     it('should handle null data gracefully', async () => {
-      manager.toastId = 'existing-toast';
+      await manager.showNotification();
       // Should not throw
       await manager.updateNotification(null);
       expect(mockNotificationManager.update).not.toHaveBeenCalled();
+    });
+
+    it('does not let a stale asynchronous update modify a newer toast', async () => {
+      await manager.showNotification();
+      const { utilsFactory } = await import('@/utils/UtilsFactory.js');
+      let resolveI18n;
+      const delayedI18n = new Promise(resolve => { resolveI18n = resolve; });
+      utilsFactory.getI18nUtils.mockImplementationOnce(() => delayedI18n);
+
+      const staleUpdate = manager.updateNotification({ status: 'translating' });
+      await Promise.resolve();
+      await manager.showNotification();
+      const currentToastId = manager.toastId;
+
+      resolveI18n({ getTranslationString: vi.fn(() => Promise.resolve('message')) });
+      await staleUpdate;
+
+      expect(mockNotificationManager.update).not.toHaveBeenCalled();
+      expect(manager.toastId).toBe(currentToastId);
     });
   });
 
   describe('dismissNotification', () => {
     it('should call notificationManager.dismiss', () => {
       manager.toastId = 'toast-to-dismiss';
+      manager.toastGeneration = manager.notificationGeneration;
+      manager.isStatusToast = true;
       
       manager.dismissNotification();
       
@@ -242,6 +310,8 @@ describe('SelectElementNotificationManager', () => {
 
     it('should replace any existing toast and show an informational message', () => {
       manager.toastId = 'progress-toast';
+      manager.toastGeneration = manager.notificationGeneration;
+      manager.isStatusToast = true;
 
       manager.showInfoNotification({ message: 'no content message' });
 
@@ -251,8 +321,18 @@ describe('SelectElementNotificationManager', () => {
         'no content message',
         'info',
         4000,
-        { id: 'select-element-toast' }
+        { id: expect.stringMatching(/^select-element-toast-\d+$/) }
       );
+    });
+
+    it('clears status ownership so stale progress cannot update an info notification', async () => {
+      await manager.showNotification();
+
+      manager.showInfoNotification({ message: 'no content message' });
+      await manager.updateNotification({ status: 'translating' });
+
+      expect(manager.toastId).toBeNull();
+      expect(mockNotificationManager.update).not.toHaveBeenCalled();
     });
 
     it('should fall back to a default message when data is missing', () => {


### PR DESCRIPTION
### Summary

* Group Action menu items into `Translators` and `Settings` submenus to stay within browser top-level menu limits.
* Fix Help navigation so it opens the correct Help tab.
* Open native shortcut settings correctly in Firefox and Chrome.
* Update shortcut navigation from both the context menu and Options UI.
* Remove obsolete Firefox shortcut-to-Help routing.
* Update shortcut help documentation for English, Persian, and Japanese.
* Prevent stale Select Element notifications after rapid reactivation.

### Validation

* Added and updated focused context-menu and shortcut tests.
* Localization checks passed.
* ESLint passed.
* `git diff --check` passed.
* Manual Chrome and Firefox smoke tests passed.
