### PR TITLE
Fix structured result publication and improve runtime diagnostics

### DIFF
--- a/src/core/managers/core/LifecycleManager.js
+++ b/src/core/managers/core/LifecycleManager.js
@@ -295,12 +295,12 @@ class LifecycleManager {
    */
   validateHandlerMappings(handlerMappings) {
     const mappedHandlers = new Set(Object.values(handlerMappings));
-    const availableHandlers = Object.values(Handlers);
-    const unmappedHandlers = availableHandlers.filter(handler => !mappedHandlers.has(handler));
+    const unmappedHandlerNames = Object.entries(Handlers)
+      .filter(([, handler]) => typeof handler === 'function' && !mappedHandlers.has(handler))
+      .map(([name]) => name);
     
-    if (unmappedHandlers.length > 0) {
-      logger.warn('Unmapped handlers detected (consider adding to handlerMappings):',
-                   unmappedHandlers.map(h => h.name || 'anonymous'));
+    if (unmappedHandlerNames.length > 0) {
+      logger.warn(`Unmapped handlers detected (consider adding to handlerMappings): ${unmappedHandlerNames.join(', ')}`);
     } else {
       logger.debug('All available handlers are properly mapped');
     }

--- a/src/core/managers/core/LifecycleManager.test.js
+++ b/src/core/managers/core/LifecycleManager.test.js
@@ -4,6 +4,8 @@ const registeredHandlers = new Map()
 const registerHandlerMock = vi.fn((action, handler) => registeredHandlers.set(action, handler))
 const translateTextHandler = vi.fn()
 const settingsUpdatedHandler = vi.fn()
+const loggerWarnMock = vi.hoisted(() => vi.fn())
+const loggerDebugMock = vi.hoisted(() => vi.fn())
 
 vi.mock('webextension-polyfill', () => ({ default: {} }))
 vi.mock('@/core/background/feature-loader.js', () => ({ featureLoader: {} }))
@@ -14,15 +16,17 @@ vi.mock('@/shared/messaging/core/MessageHandler.js', () => ({
 vi.mock('@/core/background/handlers/index.js', async (importOriginal) => ({
   ...await importOriginal(),
   handleTranslateTextLazy: translateTextHandler,
-  handleSettingsUpdatedLazy: settingsUpdatedHandler
+  handleSettingsUpdatedLazy: settingsUpdatedHandler,
+  handlerNamespaceMetadata: { source: 'test' }
 }))
 vi.mock('@/shared/logging/logger.js', () => ({
-  getScopedLogger: () => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() })
+  getScopedLogger: () => ({ debug: loggerDebugMock, info: vi.fn(), warn: loggerWarnMock, error: vi.fn() })
 }))
 vi.mock('@/core/browserHandlers.js', () => ({ addBrowserSpecificHandlers: vi.fn() }))
 vi.mock('@/utils/UtilsFactory.js', () => ({ utilsFactory: {} }))
 
 const { MessageActions } = await import('@/shared/messaging/core/MessageActions.js')
+const Handlers = await import('@/core/background/handlers/index.js')
 const { LifecycleManager } = await import('./LifecycleManager.js')
 
 describe('LifecycleManager translation text routing', () => {
@@ -94,6 +98,48 @@ describe('LifecycleManager legacy Select Element handler removal', () => {
     for (const name of LAZY_SELECT_ELEMENT_HANDLERS) {
       expect(mappedHandlers.has(Handlers[name])).toBe(true)
     }
+  })
+})
+
+describe('LifecycleManager handler mapping validation', () => {
+  beforeEach(() => {
+    loggerWarnMock.mockClear()
+    loggerDebugMock.mockClear()
+  })
+
+  it('ignores non-function namespace exports', () => {
+    const firstFunction = Object.values(Handlers).find((handler) => typeof handler === 'function')
+    const manager = new LifecycleManager()
+
+    manager.validateHandlerMappings({ mapped: firstFunction })
+
+    expect(loggerWarnMock).toHaveBeenCalledTimes(1)
+    expect(loggerWarnMock.mock.calls[0][0]).not.toContain('handlerNamespaceMetadata')
+  })
+
+  it('warns with unmapped function export names as one string argument', () => {
+    const manager = new LifecycleManager()
+
+    manager.validateHandlerMappings({})
+
+    expect(loggerWarnMock).toHaveBeenCalledTimes(1)
+    const [message, ...extraArguments] = loggerWarnMock.mock.calls[0]
+    expect(message).toContain('Unmapped handlers detected (consider adding to handlerMappings):')
+    expect(message).toContain('handleTranslateTextLazy')
+    expect(extraArguments).toHaveLength(0)
+  })
+
+  it('does not warn when all function exports are mapped', () => {
+    const allFunctionMappings = Object.fromEntries(
+      Object.entries(Handlers)
+        .filter(([, handler]) => typeof handler === 'function')
+        .map(([name, handler]) => [name, handler])
+    )
+    const manager = new LifecycleManager()
+
+    manager.validateHandlerMappings(allFunctionMappings)
+
+    expect(loggerWarnMock).not.toHaveBeenCalled()
   })
 })
 

--- a/src/features/element-selection/core/DomTranslatorAdapter.js
+++ b/src/features/element-selection/core/DomTranslatorAdapter.js
@@ -1213,12 +1213,9 @@ export class DomTranslatorAdapter extends ResourceTracker {
   }
 
   _logRejectedMapping(index, identity, reason) {
-    this.logger.warn('[DomTranslatorAdapter] Rejected translation result mapping', {
-      reason,
-      resultIndex: index,
-      identityPresent: Boolean(identity),
-      identityKnown: reason !== 'unknown',
-    });
+    this.logger.warn(
+      `[DomTranslatorAdapter] Rejected translation result mapping: reason=${reason}, resultIndex=${index}, identityPresent=${Boolean(identity)}, identityKnown=${reason !== 'unknown'}`
+    );
   }
 
   _getResultContent(item) {

--- a/src/features/element-selection/core/DomTranslatorAdapter.test.js
+++ b/src/features/element-selection/core/DomTranslatorAdapter.test.js
@@ -178,6 +178,19 @@ describe('DomTranslatorAdapter', () => {
     expect(adapter.originalSettings).toEqual({ source: 'en', target: 'fa' });
   });
 
+  it('logs rejected mapping fields as one readable warning string', () => {
+    adapter._logRejectedMapping(4, 'uid-4', 'wrong-parent');
+
+    expect(adapter.logger.warn).toHaveBeenCalledTimes(1);
+    const [message, ...extraArguments] = adapter.logger.warn.mock.calls[0];
+    expect(typeof message).toBe('string');
+    expect(message).toContain('reason=wrong-parent');
+    expect(message).toContain('resultIndex=4');
+    expect(message).toContain('identityPresent=true');
+    expect(message).toContain('identityKnown=true');
+    expect(extraArguments).toHaveLength(0);
+  });
+
   describe('translateElement', () => {
     it('should initiate a translation request', async () => {
       const onProgress = vi.fn();

--- a/src/features/translation/core/managers/OptimizedJsonHandler.js
+++ b/src/features/translation/core/managers/OptimizedJsonHandler.js
@@ -23,6 +23,7 @@ import { findProviderById } from '@/features/translation/providers/ProviderManif
 import { resolveOperationSourceLanguage } from '@/features/translation/core/OperationSourceLanguageResolver.js';
 
 const logger = getScopedLogger(LOG_COMPONENTS.TRANSLATION, 'OptimizedJsonHandler');
+const OJH_RESULT_PUBLICATION_OWNER = 'optimized-json-handler';
 const MAX_PARENT_RECOVERIES_PER_BATCH = 2;
 const GENERIC_TRANSLATION_ERROR_TYPES = new Set([
   ErrorTypes.TRANSLATION_ERROR,
@@ -1056,9 +1057,13 @@ const parentError = createParentValidationError(parentIdStr, sourceText, transla
               ...(useParentConversationLifecycle && { useParentConversationLifecycle: true }),
               ...(groupedUnitTransport && { preserveBatchUnitObjects: true }),
             };
-          batchExecutionContext = hasManifestMembership
-            ? self._createBatchExecutionContext(operationExecutionContext, batch)
-            : operationExecutionContext;
+          batchExecutionContext = {
+            ...(hasManifestMembership
+              ? self._createBatchExecutionContext(operationExecutionContext, batch)
+              : operationExecutionContext),
+            // OJH publishes accepted structured results through publishResults.
+            resultPublicationOwner: OJH_RESULT_PUBLICATION_OWNER,
+          };
           const providerPromise = self._performBatchCall(
               providerInstance, 
               batchPayload, 

--- a/src/features/translation/core/managers/OptimizedJsonHandler.test.js
+++ b/src/features/translation/core/managers/OptimizedJsonHandler.test.js
@@ -35,6 +35,30 @@ import { createManifestView, createRequestUnitManifest } from '@/features/transl
 import { TRANSLATION_BATCH_EXECUTION_TIMEOUT_MS } from '@/shared/constants/translation.js';
 import { TranslationCallPurpose } from '@/features/translation/providers/ProviderConstants.js';
 import { AIResponseParser } from '@/features/translation/providers/utils/AIResponseParser.js';
+import { BaseAIProvider } from '@/features/translation/providers/BaseAIProvider.js';
+import { AIStreamManager } from '@/features/translation/providers/utils/AIStreamManager.js';
+
+class SeamAIProvider extends BaseAIProvider {
+  constructor() {
+    super('SeamAI');
+  }
+
+  async getSupportsStreaming() {
+    return true;
+  }
+
+  async getBatchStrategy() {
+    return 'smart';
+  }
+
+  async getBatchingConfig() {
+    return { strategy: 'single', characterLimit: 5000 };
+  }
+
+  async _translateBatch(texts) {
+    return texts.map((text) => `translated:${text}`);
+  }
+}
 
 // Mock dependencies
 vi.mock('@/shared/logging/logger.js', () => ({
@@ -74,7 +98,10 @@ vi.mock('@/features/translation/core/ProviderConfigurations.js', async (importOr
 });
 
 vi.mock('@/features/translation/core/QueueManager.js', () => ({
-  queueManager: { cancelByMessageId: queueCancelMock }
+  queueManager: {
+    cancelByMessageId: queueCancelMock,
+    enqueue: vi.fn(async (_providerName, task) => task()),
+  }
 }));
 
 vi.mock('@/shared/config/config.js', () => ({
@@ -1988,6 +2015,63 @@ describe('OptimizedJsonHandler', () => {
       expect(mockProvider.translate).toHaveBeenCalledTimes(2);
       // Second call should use 'fr'
       expect(mockProvider.translate.mock.calls[1][1]).toBe('fr');
+    });
+
+    it('marks OJH ownership while publishing canonical structured results once', async () => {
+      const browser = (await import('webextension-polyfill')).default;
+      browser.tabs.sendMessage.mockClear();
+      mockEngine.createIntelligentBatches = vi.fn((segments) => [segments]);
+      mockProvider.translate.mockResolvedValueOnce({ translatedText: ['t1', 't2'] });
+
+      const result = await handler.execute(
+        mockEngine,
+        { ...mockData, sourceLanguage: 'en' },
+        mockProvider,
+        'en',
+        'fa',
+        'msg-ojh-publication-owner',
+        mockSender,
+      );
+
+      expect(result.results).toEqual(['t1', 't2']);
+      expect(mockProvider.translate.mock.calls[0][3].executionContext).toMatchObject({
+        resultPublicationOwner: 'optimized-json-handler',
+      });
+      const updates = browser.tabs.sendMessage.mock.calls
+        .map(([, message]) => message)
+        .filter((message) => message.action === MessageActions.TRANSLATION_STREAM_UPDATE);
+      expect(updates).toHaveLength(1);
+    });
+
+    it('suppresses BaseAIProvider intermediate publication while OJH publishes once', async () => {
+      const browser = (await import('webextension-polyfill')).default;
+      browser.tabs.sendMessage.mockClear();
+      mockEngine.createIntelligentBatches = vi.fn((segments) => [segments]);
+      mockEngine.getAbortController = vi.fn(() => mockAbortController);
+      const provider = new SeamAIProvider();
+      const activeSpy = vi.spyOn(AIStreamManager, 'isStreamActive').mockReturnValue(true);
+      const intermediateSpy = vi.spyOn(AIStreamManager, 'streamBatchResults').mockResolvedValue(undefined);
+
+      try {
+        const result = await handler.execute(
+          mockEngine,
+          { ...mockData, sourceLanguage: 'en' },
+          provider,
+          'en',
+          'fa',
+          'msg-ojh-base-provider-seam',
+          mockSender,
+        );
+        expect(result.results).toEqual(['translated:s1', 'translated:s2']);
+        expect(intermediateSpy).not.toHaveBeenCalled();
+        const updates = browser.tabs.sendMessage.mock.calls
+          .map(([, message]) => message)
+          .filter((message) => message.action === MessageActions.TRANSLATION_STREAM_UPDATE);
+        expect(updates).toHaveLength(1);
+      } finally {
+        activeSpy.mockRestore();
+        intermediateSpy.mockRestore();
+      }
     });
 
     it('preserves grouped Select Element units and resolves parent ownership from b', async () => {

--- a/src/features/translation/providers/BaseAIProvider.js
+++ b/src/features/translation/providers/BaseAIProvider.js
@@ -31,6 +31,7 @@ import { TranslationContractValidator } from "@/features/translation/core/Transl
 
 const logger = getScopedLogger(LOG_COMPONENTS.TRANSLATION, 'BaseAIProvider');
 const MAX_SCALAR_SELECTIVE_RECOVERY_UNITS = 3;
+const OJH_RESULT_PUBLICATION_OWNER = 'optimized-json-handler';
 
 function createConversationCommitCandidate(translateMode) {
   let staged = null;
@@ -1028,7 +1029,8 @@ export class BaseAIProvider extends BaseProvider {
 
   /**
    * Streaming batch translation implementation
-   * Sends segments in multiple batches for real-time updates
+   * Sends segments in multiple batches for real-time updates. Intermediate
+   * publication is skipped when OJH owns canonical structured publication.
    * @protected
    */
   async _streamingBatchTranslate(texts, sourceLang, targetLang, translateMode, engine, messageId, abortController, priority, sessionId, expectedFormat, options = {}) {
@@ -1109,8 +1111,9 @@ export class BaseAIProvider extends BaseProvider {
         const batchResults = Array.isArray(batchResponse) ? batchResponse : [batchResponse];
         allResults.push(...batchResults);
 
-        // Stream batch results to content script
-        if (engine && messageId) {
+        // OJH publishes mapped structured results through its canonical path.
+        if (engine && messageId
+            && options.executionContext?.resultPublicationOwner !== OJH_RESULT_PUBLICATION_OWNER) {
           await AIStreamManager.streamBatchResults(
             this.providerName,
             batchResults,

--- a/src/features/translation/providers/BaseAIProvider.test.js
+++ b/src/features/translation/providers/BaseAIProvider.test.js
@@ -2078,5 +2078,86 @@ beforeEach(() => {
         activeSpy.mockRestore();
       }
     });
+
+    it('returns OJH-owned results without intermediate AIStreamManager publication', async () => {
+      const engine = {};
+      const streamSpy = vi.spyOn(AIStreamManager, 'streamBatchResults').mockResolvedValue(undefined);
+      const activeSpy = vi.spyOn(AIStreamManager, 'isStreamActive').mockReturnValue(true);
+      const batchingSpy = vi.spyOn(provider, 'getBatchingConfig').mockResolvedValue({
+        strategy: 'single',
+        characterLimit: 5000,
+      });
+      const batchSpy = vi.spyOn(provider, '_translateBatch').mockResolvedValue(['private-result']);
+
+      try {
+        const result = await provider._streamingBatchTranslate(
+          ['source'],
+          'en',
+          'fa',
+          'selection',
+          engine,
+          'msg-ojh-owner',
+          null,
+          null,
+          null,
+          ResponseFormat.JSON_OBJECT,
+          { executionContext: { resultPublicationOwner: 'optimized-json-handler' } },
+        );
+
+        expect(result).toEqual(['private-result']);
+        expect(batchSpy).toHaveBeenCalledTimes(1);
+        expect(streamSpy).not.toHaveBeenCalled();
+      } finally {
+        streamSpy.mockRestore();
+        activeSpy.mockRestore();
+        batchingSpy.mockRestore();
+        batchSpy.mockRestore();
+      }
+    });
+
+    it('publishes provider-owned streaming results through AIStreamManager', async () => {
+      const engine = {};
+      const streamSpy = vi.spyOn(AIStreamManager, 'streamBatchResults').mockResolvedValue(undefined);
+      const activeSpy = vi.spyOn(AIStreamManager, 'isStreamActive').mockReturnValue(true);
+      const batchingSpy = vi.spyOn(provider, 'getBatchingConfig').mockResolvedValue({
+        strategy: 'single',
+        characterLimit: 5000,
+      });
+      const batchSpy = vi.spyOn(provider, '_translateBatch').mockResolvedValue(['provider-result']);
+
+      try {
+        const result = await provider._streamingBatchTranslate(
+          ['source'],
+          'en',
+          'fa',
+          'selection',
+          engine,
+          'msg-provider-owner',
+          null,
+          null,
+          null,
+          ResponseFormat.JSON_OBJECT,
+          {},
+        );
+
+        expect(result).toEqual(['provider-result']);
+        expect(batchSpy).toHaveBeenCalledTimes(1);
+        expect(streamSpy).toHaveBeenCalledWith(
+          'MockAI',
+          ['provider-result'],
+          ['source'],
+          0,
+          'msg-provider-owner',
+          engine,
+          'en',
+          'fa',
+        );
+      } finally {
+        streamSpy.mockRestore();
+        activeSpy.mockRestore();
+        batchingSpy.mockRestore();
+        batchSpy.mockRestore();
+      }
+    });
   });
 });


### PR DESCRIPTION
## Summary

* Make `OptimizedJsonHandler` the publication owner for optimized structured translation results.
* Prevent intermediate provider-level streaming from publishing non-canonical results before OJH validation and mapping.
* Preserve existing specialized-mode streaming behavior.
* Make rejected Select Element mapping warnings readable in browser extension error logs.
* Harden `LifecycleManager` handler mapping validation to ignore non-function exports.
* Include unmapped handler names directly in lifecycle warnings.

## Why

Select Element could receive raw intermediate provider results before canonical OJH mapping. This caused duplicate delivery attempts and misleading missing-identity warnings even when the final translation succeeded.

Some related diagnostics were also difficult to use because Chrome displayed structured logging arguments as `[object Object]` or `Array(...)`.

The changes keep result publication ownership explicit and make relevant warnings readable without changing global logging behavior.

## Validation

* Added focused OJH/BaseAI publication ownership coverage.
* Added Select Element logging coverage.
* Added LifecycleManager handler validation coverage.
* Verified Select Element runtime behavior with WebAI.
* Verified canonical result mapping and successful DOM reconstruction.
* `git diff --check` passes.
