### PR TITLE
Improve PDF viewer mode tooltips and Custom API settings alignment

### DIFF
--- a/src/apps/pdf/components/PdfToolbar.test.js
+++ b/src/apps/pdf/components/PdfToolbar.test.js
@@ -1921,6 +1921,56 @@ describe('PdfToolbar', () => {
     })
   })
 
+  describe('content view mode tooltips', () => {
+    const tooltipProps = (overrides = {}) => ({
+      fileName: 'doc.pdf',
+      pageCount: 3,
+      currentPageNumber: 1,
+      contentView: 'original',
+      showTranslationOption: true,
+      ...overrides
+    })
+
+    const findDesktopButtonByLabel = (wrapper, label) => wrapper
+      .findAll('.pdf-toolbar__view-mode--desktop .pdf-toolbar__mode-button')
+      .find((button) => button.text().trim() === label)
+
+    it('exposes per-mode tooltips on desktop buttons while keeping visible labels unchanged', () => {
+      const wrapper = mount(PdfToolbar, { props: tooltipProps() })
+
+      const buttons = wrapper.findAll('.pdf-toolbar__view-mode--desktop .pdf-toolbar__mode-button')
+      expect(buttons.map((button) => button.text().trim())).toEqual(['Original', 'Text', 'PDF'])
+
+      expect(findDesktopButtonByLabel(wrapper, 'Original').attributes('title')).toBe('Original PDF')
+      expect(findDesktopButtonByLabel(wrapper, 'Text').attributes('title')).toBe('Translated Text (Beta)')
+      expect(findDesktopButtonByLabel(wrapper, 'PDF').attributes('title')).toBe('Translated PDF (Experimental)')
+    })
+
+    it('sets mobile select title from the selected content view', async () => {
+      const wrapper = mount(PdfToolbar, { props: tooltipProps({ contentView: 'original' }) })
+      const select = () => wrapper.find('.pdf-toolbar__view-mode--mobile select')
+
+      expect(select().attributes('title')).toBe('Original PDF')
+      expect(wrapper.findAll('.pdf-toolbar__view-mode--mobile option').map((option) => option.text().trim()))
+        .toEqual(['Original', 'Text', 'PDF'])
+
+      await wrapper.setProps({ contentView: 'translation' })
+      expect(select().attributes('title')).toBe('Translated Text (Beta)')
+
+      await wrapper.setProps({ contentView: 'translated-pdf' })
+      expect(select().attributes('title')).toBe('Translated PDF (Experimental)')
+    })
+
+    it('keeps mode-change behavior unchanged', async () => {
+      const wrapper = mount(PdfToolbar, { props: tooltipProps({ contentView: 'original' }) })
+
+      await findDesktopButtonByLabel(wrapper, 'Text').trigger('click')
+      await wrapper.find('.pdf-toolbar__view-mode--mobile select').setValue('translated-pdf')
+
+      expect(wrapper.emitted('content-view-change')).toEqual([['translation'], ['translated-pdf']])
+    })
+  })
+
   describe('page navigation buttons', () => {
     const baseProps = () => ({
       fileName: 'doc.pdf',

--- a/src/apps/pdf/components/PdfToolbar.vue
+++ b/src/apps/pdf/components/PdfToolbar.vue
@@ -53,6 +53,7 @@
               :class="{ 'pdf-toolbar__mode-button--active': contentView === opt.value }"
               type="button"
               :aria-label="opt.ariaLabel ?? opt.label"
+              :title="opt.tooltip"
               @click="$emit('content-view-change', opt.value)"
             >
               {{ opt.label }}
@@ -67,6 +68,7 @@
           <select
             class="pdf-toolbar__view-mode-select"
             :value="contentView"
+            :title="selectedContentTooltip"
             :tabindex="showTranslationOption ? 0 : -1"
             :aria-hidden="!showTranslationOption"
             aria-label="View mode"
@@ -668,12 +670,16 @@ const activeMenu = ref(null)
 const zoomPercentOptions = PDF_ZOOM_PERCENT_OPTIONS
 
 const allContentOptions = [
-  { value: CONTENT_VIEW.ORIGINAL, label: 'Original', ariaLabel: 'Original' },
-  { value: CONTENT_VIEW.TRANSLATION, label: 'Text', ariaLabel: 'Translation' },
-  { value: CONTENT_VIEW.TRANSLATED_PDF, label: 'PDF', ariaLabel: 'Translated PDF' }
+  { value: CONTENT_VIEW.ORIGINAL, label: 'Original', ariaLabel: 'Original', tooltip: 'Original PDF' },
+  { value: CONTENT_VIEW.TRANSLATION, label: 'Text', ariaLabel: 'Translation', tooltip: 'Translated Text (Beta)' },
+  { value: CONTENT_VIEW.TRANSLATED_PDF, label: 'PDF', ariaLabel: 'Translated PDF', tooltip: 'Translated PDF (Experimental)' }
 ]
 
 const contentOptions = computed(() => allContentOptions)
+
+const selectedContentTooltip = computed(() => {
+  return contentOptions.value.find((opt) => opt.value === props.contentView)?.tooltip ?? ''
+})
 
 const isSideBySide = computed(() => props.layoutMode === LAYOUT_MODE.SIDE_BY_SIDE)
 const hasExecutionModeChoice = computed(() => props.executionModes.length > 1)

--- a/src/components/feature/api-settings/CustomApiSettings.scss
+++ b/src/components/feature/api-settings/CustomApiSettings.scss
@@ -75,6 +75,15 @@
     unicode-bidi: isolate;
   }
 
+  // URL example alignment: ProvidersTab forces width:100% on direct
+  // children of .setting-group.vertical, but the shared help text carries
+  // padding/border without border-box sizing (100% + padding + border).
+  // Border-box here (Custom URL example only) aligns its outer edge with
+  // the border-box-sized URL textbox. No width rules needed.
+  .ti-custom-api-url-example {
+    box-sizing: border-box;
+  }
+
   // Grid-stacked button labels: both labels share one cell, so the button
   // width equals the widest current-locale label with no JS measurement.
   // The inactive label keeps layout space via visibility (never

--- a/src/components/feature/api-settings/CustomApiSettings.test.js
+++ b/src/components/feature/api-settings/CustomApiSettings.test.js
@@ -852,6 +852,18 @@ describe('CustomApiSettings Test Connection', () => {
     expect(scss).toContain('var(--color-error-text)');
     expect(scss).toMatch(/\.connection-detail\s*{[^}]*color:\s*var\(--color-text\)/);
     expect(scss).not.toMatch(/#[0-9a-fA-F]{3}/);
+    // URL example: border-box alignment scoped to the Custom example only;
+    // no width rules (ProvidersTab already forces width:100% on the group).
+    expect(scss).toMatch(/\.ti-custom-api-url-example\s*{[^}]*box-sizing:\s*border-box/);
+    expect(scss).not.toMatch(/\.ti-custom-api-url-example\s*{[^}]*width:/);
+  });
+
+  it('renders the Custom URL example with the dedicated alignment class', () => {
+    const wrapper = mountWith({ CUSTOM_API_URL: URL_A, CUSTOM_API_KEY: 'k', CUSTOM_API_MODEL: 'm' });
+
+    const example = wrapper.get('p.ti-custom-api-url-example.setting-help-text');
+    expect(example.text()).toContain('https://openai.com/v1/chat/completions');
+    wrapper.unmount();
   });
 
   it('keeps layout ownership on the outer wrapper and presentation on the inner element', async () => {

--- a/src/components/feature/api-settings/CustomApiSettings.vue
+++ b/src/components/feature/api-settings/CustomApiSettings.vue
@@ -15,7 +15,7 @@
         class="api-url-input"
         dir="ltr"
       />
-      <p class="setting-help-text">
+      <p class="setting-help-text ti-custom-api-url-example">
         {{ t('custom_api_url_example') || 'Example:' }} https://openai.com/v1/chat/completions
       </p>
     </div>


### PR DESCRIPTION
## Summary

This PR includes two small UI improvements:

* Add clearer tooltips to PDF viewer content modes:

  * `Original` → `Original PDF`
  * `Text` → `Translated Text (Beta)`
  * `PDF` → `Translated PDF (Experimental)`
* Fix the Custom API URL example help text width so it aligns correctly with the API URL input.

## Details

### PDF Viewer

* Keep visible mode labels unchanged.
* Add maturity/status information through tooltips.
* Support both desktop buttons and the mobile mode selector.
* Preserve existing mode-change behavior.

### Custom API Settings

* Fix the `Example: https://openai.com/v1/chat/completions` help text overflowing the API URL input width.
* Keep the fix scoped to Custom API settings without changing shared provider styles.

## Validation

* PDF Toolbar tests: 93/93 passed.
* Custom API Settings tests: 68/68 passed.
* ESLint clean.
* No new Stylelint violations introduced.
